### PR TITLE
392 - Make Arch Site Names 1:n

### DIFF
--- a/bcap/pkg/graphs/resource_models/Archaeological Site.json
+++ b/bcap/pkg/graphs/resource_models/Archaeological Site.json
@@ -22,7 +22,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "2. Identification and Registration"
                     },
@@ -159,7 +159,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "BC Property Legal Description"
                     },
@@ -197,7 +197,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "BC Property Address"
                     },
@@ -224,7 +224,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "4. Site Location"
                     },
@@ -415,7 +415,7 @@
                     "instructions": {
                         "en": "From Sergey's mock up. Where did this come from?"
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "8. Remarks & Restricted Information"
                     },
@@ -498,7 +498,7 @@
                     "instructions": {
                         "en": "Enter any external URLs associated with this Historic Place"
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "External URLs"
                     },
@@ -525,7 +525,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "1. Site Boundary"
                     },
@@ -625,7 +625,7 @@
                     "config": null,
                     "constraints": [],
                     "cssclass": null,
-                    "description": "{\"en\": \"\"}",
+                    "description": "",
                     "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
                     "helpenabled": true,
                     "helptext": {
@@ -637,7 +637,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Site Names"
                     },
@@ -691,7 +691,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Decision History"
                     },
@@ -3831,7 +3831,7 @@
             ],
             "graphid": "cef9c510-e3e6-4057-ac08-89ad926180b4",
             "iconclass": "fa fa-bank",
-            "is_editable": true,
+            "is_editable": false,
             "isresource": true,
             "jsonldcontext": null,
             "name": {
@@ -3965,7 +3965,7 @@
                     "parentnodegroup_id": "347e24f8-01d8-11f0-850c-0242ac170007"
                 },
                 {
-                    "cardinality": "1",
+                    "cardinality": "n",
                     "legacygroupid": null,
                     "nodegroupid": "d60b1b28-35f4-11f0-afbc-0242ac170008",
                     "parentnodegroup_id": "034d1c32-13f2-11f0-9ff8-0242ac170007"
@@ -6214,7 +6214,7 @@
                         "en": ""
                     },
                     "datatype": "semantic",
-                    "description": "{\"en\": \"\"}",
+                    "description": "",
                     "exportable": false,
                     "fieldname": null,
                     "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
@@ -6756,8 +6756,8 @@
             "publication": {
                 "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
                 "notes": null,
-                "publicationid": "0a6ac772-3679-11f0-a792-0242ac170008",
-                "published_time": "2025-05-21T19:23:14.219"
+                "publicationid": "e3e90732-45ad-11f0-9be0-aeb530d39da4",
+                "published_time": "2025-06-10T03:49:20.384"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],
@@ -6790,8 +6790,8 @@
         }
     ],
     "metadata": {
-        "db": "PostgreSQL 16.3 (Debian 16.3-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
-        "git hash": "ae2a79c8b 2025-05-02 07:36:38 +0100",
+        "db": "PostgreSQL 16.4 (Debian 16.4-1.pgdg110+2) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
+        "git hash": "ae2a79c8b1 2025-05-02 07:36:38 +0100",
         "os": "Linux",
         "os version": "6.10.14-linuxkit"
     }


### PR DESCRIPTION
Arch Site Names cardinality was 1:1 but it should be 1:n as each site can have multiple names.
closes #392 