### PR TITLE
631 - Make permit holder 1:m, fix permit type collection name

### DIFF
--- a/bcap/pkg/graphs/resource_models/Archaeological Permit.json
+++ b/bcap/pkg/graphs/resource_models/Archaeological Permit.json
@@ -79,27 +79,6 @@
                 {
                     "card_id": "e6bceab2-0805-4bf8-a117-aff28e1ed741",
                     "config": {
-                        "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "Permit Holder",
-                        "placeholder": {
-                            "en": ""
-                        }
-                    },
-                    "id": "bc35f994-76d4-4abf-944a-a8c921c06ee4",
-                    "label": {
-                        "en": "Permit Holder"
-                    },
-                    "node_id": "2780d9e6-58d4-11f0-b446-0242ac170006",
-                    "sortorder": 1,
-                    "visible": true,
-                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
-                },
-                {
-                    "card_id": "e6bceab2-0805-4bf8-a117-aff28e1ed741",
-                    "config": {
                         "defaultValue": "",
                         "i18n_properties": [
                             "placeholder"
@@ -130,15 +109,6 @@
                 "en": "Model for permitting data (from the old APTS system)"
             },
             "edges": [
-                {
-                    "description": null,
-                    "domainnode_id": "588c9c3c-df62-11ef-9ad0-0242ac170009",
-                    "edgeid": "210bdb0e-ae38-41e2-bbd9-87b04a71d244",
-                    "graph_id": "f4b391f1-79d1-4886-ab2d-d72a197a9f21",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P105_right_held_by",
-                    "rangenode_id": "2780d9e6-58d4-11f0-b446-0242ac170006"
-                },
                 {
                     "description": null,
                     "domainnode_id": "588c9c3c-df62-11ef-9ad0-0242ac170009",
@@ -174,6 +144,15 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "rangenode_id": "588c9c3c-df62-11ef-9ad0-0242ac170009"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "588c9c3c-df62-11ef-9ad0-0242ac170009",
+                    "edgeid": "d184f78b-e83b-4db5-ac35-798ad102dc1a",
+                    "graph_id": "f4b391f1-79d1-4886-ab2d-d72a197a9f21",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P105_right_held_by",
+                    "rangenode_id": "3af6f67a-5926-11f0-bef3-0242ac170006"
                 }
             ],
             "functions_x_graphs": [
@@ -229,7 +208,7 @@
                         "searchDsl": "",
                         "searchString": ""
                     },
-                    "datatype": "resource-instance",
+                    "datatype": "resource-instance-list",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -241,10 +220,10 @@
                     "istopnode": false,
                     "name": "Permit Holder",
                     "nodegroup_id": "588c9c3c-df62-11ef-9ad0-0242ac170009",
-                    "nodeid": "2780d9e6-58d4-11f0-b446-0242ac170006",
+                    "nodeid": "3af6f67a-5926-11f0-bef3-0242ac170006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E39_Actor",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P105_right_held_by",
-                    "sortorder": 0,
+                    "sortorder": 3,
                     "sourcebranchpublication_id": null
                 },
                 {
@@ -336,7 +315,7 @@
                     "nodeid": "7f0349ce-df62-11ef-9ad0-0242ac170009",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E74_Group",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P105_right_held_by",
-                    "sortorder": 0,
+                    "sortorder": 1,
                     "sourcebranchpublication_id": null
                 },
                 {
@@ -359,16 +338,16 @@
                     "nodeid": "9c8ad2f0-df62-11ef-9ad0-0242ac170009",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "sortorder": 0,
+                    "sortorder": 1,
                     "sourcebranchpublication_id": null
                 }
             ],
             "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
             "publication": {
                 "graph_id": "f4b391f1-79d1-4886-ab2d-d72a197a9f21",
-                "notes": null,
-                "publicationid": "7263e872-58d4-11f0-b446-0242ac170006",
-                "published_time": "2025-07-04T12:43:12.394"
+                "notes": "Made permit holder 1:M",
+                "publicationid": "62c7edb2-5926-11f0-bef3-0242ac170006",
+                "published_time": "2025-07-04T22:29:44.938"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],


### PR DESCRIPTION
Must be merged with bcgov/nr-bcap-etl#40

Updates the Arch Permit resource model to:
- Use the right collection for Reference Type
- Change the permit holder from 1:1 -> 1:m