### PR TITLE
Remove Underscore from Related Documents Card

### DIFF
--- a/bcap/pkg/graphs/resource_models/Archaeological Site.json
+++ b/bcap/pkg/graphs/resource_models/Archaeological Site.json
@@ -280,7 +280,7 @@
                     },
                     "is_editable": true,
                     "name": {
-                        "en": "Related Documents Card"
+                        "en": "Related Documents"
                     },
                     "nodegroup_id": "2ad161ee-50ad-11f0-a6c8-0242ac170006",
                     "sortorder": 8,

--- a/bcap/pkg/graphs/resource_models/Archaeological Site.json
+++ b/bcap/pkg/graphs/resource_models/Archaeological Site.json
@@ -280,7 +280,7 @@
                     },
                     "is_editable": true,
                     "name": {
-                        "en": "Related Documents_Card"
+                        "en": "Related Documents Card"
                     },
                     "nodegroup_id": "2ad161ee-50ad-11f0-a6c8-0242ac170006",
                     "sortorder": 8,


### PR DESCRIPTION
This PR fixes the small issue from the following comment:
> Can we remove the underscore in the “Related Documents_Card” advanced search?