### PR TITLE
Update get_index_order to Match Resource Models

### DIFF
--- a/bcap/management/commands/bc_reindex_database.py
+++ b/bcap/management/commands/bc_reindex_database.py
@@ -8,15 +8,14 @@ class Command(BaseCommand):
     def get_index_order(self):
         return [
             "contributor",
-            "lg_person",
-            "local_government",
+            "government_person",
+            "government",
             "legislative_act",
             "repository",
             "hca_permit",
             "archaeological_site",
             "site_visit",
+            "archaeological_site_submission",
             "hria_discontinued_data",
-            "project_sandbox",
-            "site_form",
-            "site_submission",
+            "sandcastle"
         ]

--- a/bcap/management/commands/bc_reindex_database.py
+++ b/bcap/management/commands/bc_reindex_database.py
@@ -8,14 +8,14 @@ class Command(BaseCommand):
     def get_index_order(self):
         return [
             "contributor",
-            "government_person",
-            "government",
+            "lg_person",
+            "local_government",
             "legislative_act",
             "repository",
             "hca_permit",
             "archaeological_site",
             "site_visit",
-            "archaeological_site_submission",
             "hria_discontinued_data",
-            "sandcastle"
+            "project_sandbox",
+            "site_submission",
         ]


### PR DESCRIPTION
- I have updated the `get_index_order(...)` function in `bc_reindex_database.py` to remove "site_form", as we removed that resource model.
- This PR is complementary to: https://github.com/bcgov/bcgov-arches-common/pull/38