### PR TITLE
Align arches core dependencies with arches common

### DIFF
--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Install Python packages
       run: |
-        uv pip install --system '.[dev]'
+        uv pip install --prerelease=allow --system '.[dev]'
       shell: bash
 
     - name: Ensure frontend configuration files exist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "ajv": "^8.17.1",
-        "arches": "github:bcgov/arches#stable/7.6.12_bcgov",
+        "arches": "github:bcgov/arches#v7.6.12.1_bcgov",
         "bcgov_arches_common": "github:bcgov/bcgov-arches-common",
         "typescript": "^5.6.2"
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "arches @ git+https://github.com/bcgov/arches@v7.6.12.1_bcgov",
+    "arches_component_lab",
     "bcgov_arches_common @ git+https://github.com/bcgov/bcgov-arches-common",
     "boto3==1.26",
     "django-storages==1.13",
@@ -35,7 +36,7 @@ dependencies = [
     "Authlib",
 ]
 
-version = "0.0.1-a"
+version = "0.0.1"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arches @ git+https://github.com/bcgov/arches.git@stable/7.6.12_bcgov",
-    "bcgov_arches_common @ git+https://github.com/bcgov/bcgov-arches-common.git",
+    "arches @ git+https://github.com/bcgov/arches@v7.6.12.1_bcgov",
+    "bcgov_arches_common @ git+https://github.com/bcgov/bcgov-arches-common",
     "boto3==1.26",
     "django-storages==1.13",
     "redis",


### PR DESCRIPTION
This fixes the GitHub CI by:
- Updates the arches core dependency to align with bcgov-arches-common 1.2.4
- Allows pre-release dependencies to allow use of the arches-component-lab for Vue widgets
- Removes Python 3.10 from list of test versions

This can be merged even though the build target branch is failing - it fixes that issue.