### PR TITLE
Brf/feat/make vite conditional

### DIFF
--- a/bcap/settings.py
+++ b/bcap/settings.py
@@ -222,7 +222,6 @@ INSTALLED_APPS = (
     "django_celery_results",
     # "compressor",
     # "silk",
-    "django_vite",
     "storages",
     "bcap",
     "arches_querysets",
@@ -239,6 +238,11 @@ INSTALLED_APPS += (
 # toggle Vite injection
 USE_VITE = False
 VITE_BASE = "/bcap/@vite/"
+
+if USE_VITE:
+    INSTALLED_APPS += (
+        "django_vite",
+    )
 
 # These are the Vue entrypoints that can be served by Vite on a page-by-page basis.
 VITE_ENTRYPOINTS = {"/bcap/search": ["bcap/vite-entries/bcap-site.entry.js"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "django-migrate-sql-deux==1.1.1",
     "django-pgtrigger==4.15.2",
     "django-storages==1.13",
-    "django-vite",
     "redis",
     "python-dotenv",
     "oracledb",


### PR DESCRIPTION
1. Only adds the django_vite app to INSTALLED_APPS if USE_VITE is True. 
2. Reorganize the python dependencies so it isn't installed on the target servers.