### PR TITLE
Fix Regressions

### DIFF
--- a/bcap/pkg/graphs/resource_models/Archaeological Site Submission.json
+++ b/bcap/pkg/graphs/resource_models/Archaeological Site Submission.json
@@ -176,12 +176,10 @@
                 {
                     "card_id": "496b9d34-958a-41fd-8302-d6d877bbb477",
                     "config": {
-                        "defaultValue": "",
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Requested Operation",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -194,7 +192,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "247a4e3c-3122-4351-9b1e-83f1d5e104bb",
@@ -938,8 +936,11 @@
                 },
                 {
                     "alias": "requested_operation",
-                    "config": {},
-                    "datatype": "concept",
+                    "config": {
+                        "controlledList": "56c3460e-e1b5-5afc-93ff-3625b652302b",
+                        "multiValue": false
+                    },
+                    "datatype": "reference",
                     "description": "Addition, Removal or Update.\nShould this be assigned at the Site level? Eg - do you want to allow ",
                     "exportable": true,
                     "fieldname": "RQSTD_OP",
@@ -987,7 +988,7 @@
                 {
                     "alias": "submission_type",
                     "config": {
-                        "controlledList": "c99b8763-d118-4869-9c58-4bcbf705e810",
+                        "controlledList": "0868cf04-7b9f-5be1-99ae-24074540603c",
                         "multiValue": true
                     },
                     "datatype": "reference",

--- a/bcap/pkg/graphs/resource_models/Archaeological Site.json
+++ b/bcap/pkg/graphs/resource_models/Archaeological Site.json
@@ -2181,20 +2181,6 @@
                     "card_id": "034d1e3a-13f2-11f0-9ff8-0242ac170007",
                     "config": {
                         "defaultValue": {
-                            "__ko_mapping__": {
-                                "copiedProperties": {},
-                                "copy": [],
-                                "ignore": [],
-                                "include": [
-                                    "_destroy"
-                                ],
-                                "mappedProperties": {
-                                    "en": true,
-                                    "en.direction": true,
-                                    "en.value": true
-                                },
-                                "observe": []
-                            },
                             "en": {
                                 "direction": "ltr",
                                 "value": ""
@@ -2346,57 +2332,6 @@
                     "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
                 },
                 {
-                    "card_id": "14be7a8e-c87a-4b40-815a-f872d77b0c10",
-                    "config": {
-                        "defaultValue": {
-                            "en": {
-                                "direction": "ltr",
-                                "value": ""
-                            }
-                        },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "Typology Descriptor",
-                        "maxLength": null,
-                        "placeholder": {
-                            "en": "Enter text"
-                        },
-                        "uneditable": false,
-                        "width": "100%"
-                    },
-                    "id": "aee06008-ade9-4c45-9a5d-5135139e269e",
-                    "label": {
-                        "en": "Typology Descriptor"
-                    },
-                    "node_id": "a2bc804e-01c0-11f0-97f7-0242ac170007",
-                    "sortorder": 3,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
-                },
-                {
-                    "card_id": "14be7a8e-c87a-4b40-815a-f872d77b0c10",
-                    "config": {
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "Site Type",
-                        "placeholder": {
-                            "en": "Select an option"
-                        }
-                    },
-                    "id": "b02c4973-98f9-4a17-a638-3f6abc2ed402",
-                    "label": {
-                        "en": "Site Type"
-                    },
-                    "node_id": "6ebdd1e4-01c0-11f0-97f7-0242ac170007",
-                    "sortorder": 1,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
-                },
-                {
                     "card_id": "b0ed3390-61a4-11f0-9674-3a7a4e6803c5",
                     "config": {
                         "defaultValue": {
@@ -2537,27 +2472,6 @@
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
-                },
-                {
-                    "card_id": "14be7a8e-c87a-4b40-815a-f872d77b0c10",
-                    "config": {
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "Site Subtype",
-                        "placeholder": {
-                            "en": "Select an option"
-                        }
-                    },
-                    "id": "b6c275cd-f02f-47c7-b1b1-9fafef1e97e9",
-                    "label": {
-                        "en": "Site Subtype"
-                    },
-                    "node_id": "897b6280-01c0-11f0-97f7-0242ac170007",
-                    "sortorder": 2,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",
@@ -3199,20 +3113,6 @@
                     "card_id": "b0ed3390-61a4-11f0-9674-3a7a4e6803c5",
                     "config": {
                         "defaultValue": {
-                            "__ko_mapping__": {
-                                "copiedProperties": {},
-                                "copy": [],
-                                "ignore": [],
-                                "include": [
-                                    "_destroy"
-                                ],
-                                "mappedProperties": {
-                                    "en": true,
-                                    "en.direction": true,
-                                    "en.value": true
-                                },
-                                "observe": []
-                            },
                             "en": {
                                 "direction": "ltr",
                                 "value": ""
@@ -3459,27 +3359,6 @@
                     },
                     "node_id": "f80f08ae-1977-11f0-8713-0242ac170008",
                     "sortorder": 2,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
-                },
-                {
-                    "card_id": "f80f0aac-1977-11f0-8713-0242ac170008",
-                    "config": {
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "Decision Criteria",
-                        "placeholder": {
-                            "en": "Select an option"
-                        }
-                    },
-                    "id": "f80f145c-1977-11f0-8713-0242ac170008",
-                    "label": {
-                        "en": "Decision Criteria"
-                    },
-                    "node_id": "f80f0e44-1977-11f0-8713-0242ac170008",
-                    "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
@@ -3800,16 +3679,6 @@
                 },
                 {
                     "description": null,
-                    "domainnode_id": "3083c10e-01c0-11f0-97f7-0242ac170007",
-                    "edgeid": "198a596f-06b9-4fc7-82ab-7dc23c38e2ac",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "rangenode_id": "6ebdd1e4-01c0-11f0-97f7-0242ac170007",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
                     "domainnode_id": "1b622e58-0d0f-11ed-98c2-5254008afee6",
                     "edgeid": "1b62a37e-0d0f-11ed-98c2-5254008afee6",
                     "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
@@ -4086,16 +3955,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "rangenode_id": "2255168c-1c55-11f0-9b6d-0242ac170007",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "6ebdd1e4-01c0-11f0-97f7-0242ac170007",
-                    "edgeid": "59ca586c-c9f1-419c-b62b-e62768e4d1ae",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P127i_has_narrower_term",
-                    "rangenode_id": "897b6280-01c0-11f0-97f7-0242ac170007",
                     "source_identifier_id": null
                 },
                 {
@@ -4810,16 +4669,6 @@
                 },
                 {
                     "description": null,
-                    "domainnode_id": "3083c10e-01c0-11f0-97f7-0242ac170007",
-                    "edgeid": "e1757843-5aa4-4a2c-b2af-94ea049750be",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P140i_was_attributed_by",
-                    "rangenode_id": "a2bc804e-01c0-11f0-97f7-0242ac170007",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
                     "domainnode_id": "1b622e58-0d0f-11ed-98c2-5254008afee6",
                     "edgeid": "e51f7d05-40b0-4ed7-bcad-2bfb29b00bbd",
                     "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
@@ -4866,16 +4715,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P14_carried_out_by",
                     "rangenode_id": "f80f0d4a-1977-11f0-8713-0242ac170008",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "f80f08ae-1977-11f0-8713-0242ac170008",
-                    "edgeid": "f80f3f0e-1977-11f0-8713-0242ac170008",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P15_was_influenced_by",
-                    "rangenode_id": "f80f0e44-1977-11f0-8713-0242ac170008",
                     "source_identifier_id": null
                 },
                 {
@@ -7029,32 +6868,6 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "site_type",
-                    "config": {
-                        "controlledList": "2162c324-c7e4-55e3-9f0b-5e7a40266bf2",
-                        "multiValue": false
-                    },
-                    "datatype": "reference",
-                    "description": null,
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Site Type",
-                    "nodegroup_id": "3083c10e-01c0-11f0-97f7-0242ac170007",
-                    "nodeid": "6ebdd1e4-01c0-11f0-97f7-0242ac170007",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "sortorder": 1,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
                     "alias": "biogeography_type",
                     "config": {
                         "controlledList": "9947b6d4-e7e8-5d32-a8cf-b978fa27f31d",
@@ -7272,32 +7085,6 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "site_subtype",
-                    "config": {
-                        "controlledList": "79332c30-c369-5852-b3ea-023551fd9d34",
-                        "multiValue": false
-                    },
-                    "datatype": "reference",
-                    "description": "Can this be a single, hierarchical list?",
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Site Subtype",
-                    "nodegroup_id": "3083c10e-01c0-11f0-97f7-0242ac170007",
-                    "nodeid": "897b6280-01c0-11f0-97f7-0242ac170007",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P127i_has_narrower_term",
-                    "sortorder": 2,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
                     "alias": "registry_types2",
                     "config": {
                         "controlledList": "b9838a3b-731d-5c4b-b6c8-23ed827dbb7e",
@@ -7368,31 +7155,6 @@
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E62_String",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "sortorder": 0,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "typology_descriptor",
-                    "config": {
-                        "en": ""
-                    },
-                    "datatype": "string",
-                    "description": null,
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Typology Descriptor",
-                    "nodegroup_id": "3083c10e-01c0-11f0-97f7-0242ac170007",
-                    "nodeid": "a2bc804e-01c0-11f0-97f7-0242ac170007",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E14_Condition_Assessment",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P140i_was_attributed_by",
-                    "sortorder": 2,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -8725,32 +8487,6 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "decision_criteria",
-                    "config": {
-                        "controlledList": "5ef2a67b-4ebf-58d0-919e-66965be03cb7",
-                        "multiValue": false
-                    },
-                    "datatype": "reference",
-                    "description": "The criteria made to make the decision. Collection needs to be updated.",
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": true,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Decision Criteria",
-                    "nodegroup_id": "f80f08ae-1977-11f0-8713-0242ac170008",
-                    "nodeid": "f80f0e44-1977-11f0-8713-0242ac170008",
-                    "ontologyclass": "http://www.ics.forth.gr/isl/CRMinf/I3_Inference_Logic",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P15_was_influenced_by",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
                     "alias": "recommended_by",
                     "config": {
                         "graphs": [
@@ -8866,9 +8602,9 @@
             "publication": {
                 "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
                 "most_recent_edit_id": null,
-                "notes": "First cut of changes for #831. Need to update ETL for some changes made here.",
-                "publicationid": "92a0da32-8b0d-49ad-92a7-f5ba3e9beec9",
-                "published_time": "2025-09-10T03:52:22.575"
+                "notes": null,
+                "publicationid": "a8dd373c-e912-4f46-bf57-68790eb3a15c",
+                "published_time": "2025-09-17T18:09:37.313"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],
@@ -8967,9 +8703,9 @@
         }
     ],
     "metadata": {
-        "db": "PostgreSQL 16.3 (Debian 16.3-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
-        "git hash": "b5d7f74e79 2025-09-09 14:54:48 -0700",
+        "db": "PostgreSQL 16.4 (Debian 16.4-1.pgdg110+2) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
+        "git hash": "fatal: not a git repository (or any of the parent directories): .git",
         "os": "Linux",
-        "os version": "6.10.14-linuxkit"
+        "os version": "6.6.87.2-microsoft-standard-WSL2"
     }
 }

--- a/bcap/pkg/graphs/resource_models/Archaeological Site.json
+++ b/bcap/pkg/graphs/resource_models/Archaeological Site.json
@@ -8639,7 +8639,7 @@
                 {
                     "alias": "site_decision",
                     "config": {
-                        "controlledList": "5ef2a67b-4ebf-58d0-919e-66965be03cb7",
+                        "controlledList": "a05e2998-03b7-552d-8bad-d398230b1222",
                         "en": "",
                         "multiValue": false
                     },

--- a/bcap/pkg/graphs/resource_models/HRIA Discontinued Data.json
+++ b/bcap/pkg/graphs/resource_models/HRIA Discontinued Data.json
@@ -2346,7 +2346,7 @@
                 {
                     "alias": "end_year_qualifier",
                     "config": {
-                        "controlledList": "d94edecb-1c9c-43aa-9abc-4aec1f7d19f5",
+                        "controlledList": "67c5c941-e6c2-56aa-a224-7b878ffdb6ec",
                         "multiValue": false
                     },
                     "datatype": "reference",
@@ -2575,7 +2575,7 @@
                 {
                     "alias": "start_year_qualifier",
                     "config": {
-                        "controlledList": "d94edecb-1c9c-43aa-9abc-4aec1f7d19f5",
+                        "controlledList": "67c5c941-e6c2-56aa-a224-7b878ffdb6ec",
                         "multiValue": false
                     },
                     "datatype": "reference",

--- a/bcap/pkg/graphs/resource_models/Repository.json
+++ b/bcap/pkg/graphs/resource_models/Repository.json
@@ -876,7 +876,7 @@
                 {
                     "alias": "province",
                     "config": {
-                        "controlledList": "d49579da-a691-4a31-a09b-495f078a448b",
+                        "controlledList": "9affa732-8bbe-501f-8e24-e25b48a47e78",
                         "multiValue": false
                     },
                     "datatype": "reference",

--- a/bcap/pkg/graphs/resource_models/Site Visit.json
+++ b/bcap/pkg/graphs/resource_models/Site Visit.json
@@ -3987,7 +3987,7 @@
                 {
                     "alias": "archaeological_feature",
                     "config": {
-                        "controlledList": "1a6495f4-0ef4-469a-9e62-5e39b1c96a10",
+                        "controlledList": "d3b24bed-65fb-5e43-9479-1d3e0cba482c",
                         "multiValue": false
                     },
                     "datatype": "reference",

--- a/bcap/settings.py
+++ b/bcap/settings.py
@@ -240,9 +240,7 @@ USE_VITE = False
 VITE_BASE = "/bcap/@vite/"
 
 if USE_VITE:
-    INSTALLED_APPS += (
-        "django_vite",
-    )
+    INSTALLED_APPS += ("django_vite",)
 
     # These are the Vue entrypoints that can be served by Vite on a page-by-page basis.
     VITE_ENTRYPOINTS = {"/bcap/search": ["bcap/vite-entries/bcap-site.entry.js"]}

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection2.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection2.vue
@@ -79,14 +79,20 @@ const labelize = (key: string) =>
 
 const decisionData = computed(() => currentData.value?.site_decision);
 
-const { processedData: decisionTableData, isProcessing: isProcessingDecisions } = useHierarchicalData(
-    decisionData,
-    {
-        sourceField: 'site_decision',
-        hierarchicalFields: ['site_decision', 'decision_criteria'],
-        flatFields: ['decision_date', 'decision_made_by', 'decision_description', 'recommendation_date', 'recommended_by']
-    }
-);
+const {
+    processedData: decisionTableData,
+    isProcessing: isProcessingDecisions,
+} = useHierarchicalData(decisionData, {
+    sourceField: "site_decision",
+    hierarchicalFields: ["site_decision", "decision_criteria"],
+    flatFields: [
+        "decision_date",
+        "decision_made_by",
+        "decision_description",
+        "recommendation_date",
+        "recommended_by",
+    ],
+});
 </script>
 
 <template>

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection2.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection2.vue
@@ -83,8 +83,8 @@ const { processedData: decisionTableData, isProcessing: isProcessingDecisions } 
     decisionData,
     {
         sourceField: 'site_decision',
-        hierarchyFields: ['site_decision', 'decision_criteria'],
-        otherFields: ['decision_date', 'decision_made_by', 'decision_description', 'recommendation_date', 'recommended_by']
+        hierarchicalFields: ['site_decision', 'decision_criteria'],
+        flatFields: ['decision_date', 'decision_made_by', 'decision_description', 'recommendation_date', 'recommended_by']
     }
 );
 </script>

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection2.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection2.vue
@@ -2,11 +2,11 @@
 import { computed } from "vue";
 import DetailsSection from "@/bcap/components/DetailsSection/DetailsSection.vue";
 import { getDisplayValue, isEmpty } from "@/bcap/util.ts";
+import { useHierarchicalData } from "@/bcap/composables/useHierarchicalData.ts";
 import type {
     AliasedNodeData,
     AliasedTileData,
 } from "@/arches_component_lab/types.ts";
-// main.js or in your component's script setup
 import StandardDataTable from "@/bcgov_arches_common/components/StandardDataTable/StandardDataTable.vue";
 import "primeicons/primeicons.css";
 import type { IdentificationAndRegistrationTile } from "@/bcap/schema/ArchaeologySiteSchema.ts";
@@ -76,12 +76,23 @@ type IdFieldKey = (typeof id_fields)[number];
 // Turn "borden_number" -> "Borden Number"
 const labelize = (key: string) =>
     key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+
+const decisionData = computed(() => currentData.value?.site_decision);
+
+const { processedData: decisionTableData, isProcessing: isProcessingDecisions } = useHierarchicalData(
+    decisionData,
+    {
+        sourceField: 'site_decision',
+        hierarchyFields: ['site_decision', 'decision_criteria'],
+        otherFields: ['decision_date', 'decision_made_by', 'decision_description', 'recommendation_date', 'recommended_by']
+    }
+);
 </script>
 
 <template>
     <DetailsSection
         section-title="2. ID & Registration"
-        :loading="props.loading"
+        :loading="props.loading || isProcessingDecisions"
         :visible="true"
     >
         <template #sectionContent>
@@ -152,7 +163,7 @@ const labelize = (key: string) =>
                     :initial-sort-field-index="3"
                 ></StandardDataTable>
                 <StandardDataTable
-                    :table-data="currentData?.site_decision || []"
+                    :table-data="decisionTableData"
                     :column-definitions="siteDecisionColumns"
                     title="Decision History"
                     :initial-sort-field-index="0"

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection6.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection6.vue
@@ -37,8 +37,8 @@ const { processedData: typologyTableData, isProcessing } = useHierarchicalData(
     typologyData,
     {
         sourceField: 'typology_class',
-        hierarchyFields: ['typology_class', 'site_type', 'site_subtype', 'typology_descriptor'],
-        otherFields: ['typology_remark']
+        hierarchicalFields: ['typology_class', 'site_type', 'site_subtype', 'typology_descriptor'],
+        flatFields: ['typology_remark']
     }
 );
 </script>

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection6.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection6.vue
@@ -36,10 +36,15 @@ const typologyData = computed(() => currentData.value?.site_typology);
 const { processedData: typologyTableData, isProcessing } = useHierarchicalData(
     typologyData,
     {
-        sourceField: 'typology_class',
-        hierarchicalFields: ['typology_class', 'site_type', 'site_subtype', 'typology_descriptor'],
-        flatFields: ['typology_remark']
-    }
+        sourceField: "typology_class",
+        hierarchicalFields: [
+            "typology_class",
+            "site_type",
+            "site_subtype",
+            "typology_descriptor",
+        ],
+        flatFields: ["typology_remark"],
+    },
 );
 </script>
 

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection6.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection6.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import DetailsSection from "@/bcap/components/DetailsSection/DetailsSection.vue";
-
+import { useHierarchicalData } from "@/bcap/composables/useHierarchicalData.ts";
 import StandardDataTable from "@/bcgov_arches_common/components/StandardDataTable/StandardDataTable.vue";
 import "primeicons/primeicons.css";
 import type { ArchaeologicalDataTile } from "@/bcap/schema/ArchaeologySiteSchema.ts";
@@ -23,7 +23,6 @@ const currentData = computed<ArchaeologicalDataTile | undefined>(
     },
 );
 
-/** Generic column definitions: configure any key/path + label */
 const typologyColumns = [
     { field: "typology_class", label: "Class" },
     { field: "site_type", label: "Type" },
@@ -31,23 +30,32 @@ const typologyColumns = [
     { field: "typology_descriptor", label: "Descriptor" },
     { field: "typology_remark", label: "Remarks" },
 ];
+
+const typologyData = computed(() => currentData.value?.site_typology);
+
+const { processedData: typologyTableData, isProcessing } = useHierarchicalData(
+    typologyData,
+    {
+        sourceField: 'typology_class',
+        hierarchyFields: ['typology_class', 'site_type', 'site_subtype', 'typology_descriptor'],
+        otherFields: ['typology_remark']
+    }
+);
 </script>
 
 <template>
     <DetailsSection
         section-title="6. Archaeological Data"
-        :loading="props.loading"
+        :loading="props.loading || isProcessing"
         :visible="true"
     >
         <template #sectionContent>
-            <div>
-                <StandardDataTable
-                    :table-data="currentData?.site_typology ?? []"
-                    :column-definitions="typologyColumns"
-                    title="Site Typology"
-                    initial-sort-field="0"
-                ></StandardDataTable>
-            </div>
+            <StandardDataTable
+                :table-data="typologyTableData"
+                :column-definitions="typologyColumns"
+                title="Site Typology"
+                :initial-sort-field-index="0"
+            />
         </template>
     </DetailsSection>
 </template>

--- a/bcap/src/bcap/composables/useHierarchicalData.ts
+++ b/bcap/src/bcap/composables/useHierarchicalData.ts
@@ -1,0 +1,121 @@
+import { ref, watch, type Ref } from "vue";
+import type { AliasedTileData, AliasedNodeData } from "@/arches_component_lab/types.ts";
+
+interface HierarchicalFieldConfig {
+    sourceField: string;
+    hierarchyFields: string[];
+    otherFields?: string[];
+}
+
+async function fetchHierarchy(listItemId: string): Promise<string[]> {
+    try {
+        const response = await fetch(`/bcap/api/hierarchy/${listItemId}/`);
+
+        if (!response.ok) {
+            console.error(`Failed to fetch hierarchy for ${listItemId}: ${response.status}`);
+            return [];
+        }
+
+        const data = await response.json();
+        return data.labels || [];
+    } catch (error) {
+        console.error(`API error for ${listItemId}:`, error);
+        return [];
+    }
+}
+
+export function useHierarchicalData(
+    dataSource: Ref<AliasedTileData[] | undefined>,
+    config: HierarchicalFieldConfig
+) {
+    const processedData = ref<AliasedTileData[]>([]);
+    const isProcessing = ref(false);
+
+    async function loadData() {
+        if (!dataSource.value || !dataSource.value.length) {
+            processedData.value = [];
+            return;
+        }
+
+        isProcessing.value = true;
+
+        try {
+            const results = await Promise.all(
+                dataSource.value.map(async (item: any, index: number) => {
+                    const originalData = item.aliased_data || item;
+
+                    let listItemId = null;
+
+                    const sourceNode = originalData[config.sourceField];
+
+                    if (sourceNode?.node_value?.[0]?.uri) {
+                        const uriMatch = sourceNode.node_value[0].uri.match(/item\/([a-f0-9-]+)$/);
+
+                        if (uriMatch) {
+                            listItemId = uriMatch[1];
+                        }
+                    }
+
+                    let hierarchy: string[] = [];
+
+                    if (listItemId) {
+                        hierarchy = await fetchHierarchy(listItemId);
+                    }
+
+                    if (!hierarchy.length && sourceNode?.display_value) {
+                        hierarchy = [sourceNode.display_value];
+                    }
+
+                    const aliasedData: Record<string, AliasedNodeData> = {};
+
+                    config.hierarchyFields.forEach((field, idx) => {
+                        aliasedData[field] = {
+                            node_value: hierarchy[idx] || null,
+                            display_value: hierarchy[idx] || '',
+                            details: []
+                        };
+                    });
+
+                    config.otherFields?.forEach(field => {
+                        aliasedData[field] = originalData[field] || {
+                            node_value: null,
+                            display_value: '',
+                            details: []
+                        };
+                    });
+
+                    const transformedRow: AliasedTileData = {
+                        tileid: item.tileid || `${config.sourceField}-${index}`,
+                        resourceinstance: item.resourceinstance,
+                        nodegroup: item.nodegroup,
+                        parenttile: item.parenttile,
+                        sortorder: item.sortorder || index,
+                        provisionaledits: item.provisionaledits,
+                        aliased_data: aliasedData
+                    };
+
+                    return transformedRow;
+                })
+            );
+
+            processedData.value = results;
+        } catch (error) {
+            console.error(`Error processing ${config.sourceField} data:`, error);
+            processedData.value = [];
+        } finally {
+            isProcessing.value = false;
+        }
+    }
+
+    watch(dataSource, (newVal) => {
+        if (newVal) {
+            loadData();
+        }
+    }, { immediate: true });
+
+    return {
+        processedData,
+        isProcessing,
+        reload: loadData
+    };
+}

--- a/bcap/urls.py
+++ b/bcap/urls.py
@@ -9,6 +9,7 @@ from bcap.views.api import (
     LegislativeAct,
     UserProfile,
     RelatedSiteVisits,
+    ControlledListHierarchy
 )
 from bcap.views.resource import ResourceReportView
 from bcgov_arches_common.views.map import BCTileserverProxyView
@@ -61,6 +62,11 @@ urlpatterns = [
         bc_path_prefix(r"^legislative_act/(?P<act_id>%s)$" % uuid_regex),
         LegislativeAct.as_view(),
         name="legislative_act",
+    ),
+    re_path(
+        bc_path_prefix(r"^api/hierarchy/(?P<list_item_id>%s)/$" % uuid_regex),
+        ControlledListHierarchy.as_view(),
+        name="controlled_list_hierarchy",
     ),
     re_path(
         bc_path_prefix(r"^user_profile$"),

--- a/bcap/urls.py
+++ b/bcap/urls.py
@@ -9,7 +9,7 @@ from bcap.views.api import (
     LegislativeAct,
     UserProfile,
     RelatedSiteVisits,
-    ControlledListHierarchy
+    ControlledListHierarchy,
 )
 from bcap.views.resource import ResourceReportView
 from bcgov_arches_common.views.map import BCTileserverProxyView

--- a/bcap/views/api.py
+++ b/bcap/views/api.py
@@ -139,10 +139,14 @@ class ControlledListHierarchy(APIBase):
             labels = []
 
             while item:
-                label = ListItemValue.objects.filter(
-                    list_item=item,
-                    valuetype_id='prefLabel',
-                ).values_list('value', flat=True).first()
+                label = (
+                    ListItemValue.objects.filter(
+                        list_item=item,
+                        valuetype_id="prefLabel",
+                    )
+                    .values_list("value", flat=True)
+                    .first()
+                )
 
                 if label:
                     labels.append(label)
@@ -151,6 +155,6 @@ class ControlledListHierarchy(APIBase):
 
             labels.reverse()
 
-            return JSONResponse({'labels': labels})
+            return JSONResponse({"labels": labels})
         except ListItem.DoesNotExist:
-            return JSONResponse({'labels': []})
+            return JSONResponse({"labels": []})


### PR DESCRIPTION
This will need to be merged with: https://github.com/bcgov-c/nr-bcap-etl/pull/75

- Fixed missing `Biogeography` data in ETL, the frontend will need to be done
- Fixed missing `Site Typology` fields by properly implementing hierarchical data structure in frontend
- Refactored `Decision History` to use new hierarchical structure, so everything is contained within one widget and represented and displayed correctly
- Resolved frontend loading failures caused by `__ko_mapping__` sections in resource models that were breaking JSON parsing and `arches-queryset` serialization
- Resolved issue where editing controlled list fields caused URLs to revert to `localhost:8000` instead of maintaining correct base URL after saving
- The loading circle display bug seems to be fixed in latest container refresh/dependency upgrades

- I'm not 100% sure this would close  bcgov/nr-bcap#404, as it appears to be also related to advanced search (which wasn't addressed here), but everything else should be fine from what I've observed.

closes bcgov/nr-bcap#404
closes bcgov/nr-bcap#843 
closes bcgov/nr-bcap#844 
closes bcgov/nr-bcap#845 
closes bcgov/nr-bcap#925 
closes bcgov/nr-bcap#926 