### PR TITLE
Change MEDIA_URL to allow requests to be passed through to S3 service.

### DIFF
--- a/bcap/settings.py
+++ b/bcap/settings.py
@@ -326,7 +326,7 @@ WSGI_APPLICATION = "bcap.wsgi.application"
 
 # URL that handles the media served from MEDIA_ROOT, used for managing stored files.
 # It must end in a slash if set to a non-empty value.
-MEDIA_URL = "/files/"
+MEDIA_URL = "/localfiles/"
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 MEDIA_ROOT = os.path.join(APP_ROOT)


### PR DESCRIPTION
Closes #829 

Fixes setting that was forcing all media request to try to be served from the local filesystem. Change the MEIDA_URL to /localfiles/ so it could potentially be used in the future to serve non-business-related static assets.