### PR TITLE
Disable custom ES mappings for x-model search clarity

### DIFF
--- a/bcap/settings.py
+++ b/bcap/settings.py
@@ -170,7 +170,7 @@ TERM_SEARCH_TYPES = [
 
 ES_MAPPING_MODIFIER_CLASSES = [
     "arches_controlled_lists.search.references_es_mapping_modifier.ReferencesEsMappingModifier",
-    "bcap.search.arch_site_es_values.CustomSearchValue",
+    # "bcap.search.arch_site_es_values.CustomSearchValue"
 ]
 
 KIBANA_URL = "http://localhost:5601/"


### PR DESCRIPTION
We should disable the custom ES mapping so that when testing of the x-model search functionality is done, the results are clear. This also significantly reduces the time it takes to reindex the database, so if the custom mapping isn't necessary we shouldn't continue to do it.