### PR TITLE
Add Uneditable Toggle to base.htm and map.htm

### DIFF
--- a/bcap/templates/views/components/widgets/base.htm
+++ b/bcap/templates/views/components/widgets/base.htm
@@ -22,5 +22,24 @@
 
 <!-- ko if: configForm -->
 {% block config_form %}
+<div class="node-config-item">
+    <div class="control-label">
+        <span>Disable Editing</span>
+    </div>
+    <div class="pad-no">
+        <div data-bind="
+            component: {
+                name: 'views/components/simple-switch',
+                params: {
+                    value: uneditable,
+                    config:{
+                        label: 'Uneditable',
+                        subtitle: 'Prevent users from editing this value'
+                    }
+                }
+            }">
+        </div>
+    </div>
+</div>
 {% endblock config_form %}
 <!-- /ko -->

--- a/bcap/templates/views/components/widgets/map.htm
+++ b/bcap/templates/views/components/widgets/map.htm
@@ -103,6 +103,7 @@
         "
     >
 </div>
+{{ block.super }}
 {% endblock config_form %}
 
 {% block display_value %}


### PR DESCRIPTION
I am updating `templates/views/components/widgets/base.htm`, because BCAP appears to override the one in Arches. So, I have added the same default toggle element to `{% block config_form %}` so we can disable editing fields in BCAP, and then I'm also applying it to a BCAP specific widget.

https://github.com/bcgov/arches/pull/6/ is supposed to be merged after
ideally we're merging this to `archesproject/arches`