### PR TITLE
1165 - Make displayname text-searchable

### DIFF
--- a/bcap/settings.py
+++ b/bcap/settings.py
@@ -171,6 +171,7 @@ TERM_SEARCH_TYPES = [
 ES_MAPPING_MODIFIER_CLASSES = [
     "arches_controlled_lists.search.references_es_mapping_modifier.ReferencesEsMappingModifier",
     # "bcap.search.arch_site_es_values.CustomSearchValue"
+    "bcgov_arches_common.search.displayname_es_values.DisplayDescriptorSearchValue",
 ]
 
 KIBANA_URL = "http://localhost:5601/"


### PR DESCRIPTION
Add ES modifier class to make displayname values text-serchable (not just term searchable)

This PR must be merged with/after bcgov/bcgov-arches-common#84

closes #1162