### PR TITLE
Handle Bare Shapefile and Other Coordinate Reference Systems

### DIFF
--- a/bcap/media/js/viewmodels/map-editor.js
+++ b/bcap/media/js/viewmodels/map-editor.js
@@ -1,203 +1,37 @@
-import $ from 'jquery';
-import _ from 'underscore';
-import ko from 'knockout';
-import koMapping from 'knockout-mapping';
-import slick from 'slick';
-import arches from 'arches';
-import MapReportViewModel from 'viewmodels/map-report';
-import chosen from 'bindings/chosen';
-import uuid from 'uuid';
-import geojsonExtent from 'geojson-extent';
-import geojsonhint from 'geojsonhint';
-import { kml } from 'togeojson';
-import shp from 'shpjsesm';
-import proj4 from 'proj4';
-import MapboxDraw from 'mapbox-gl-draw';
-import MapComponentViewModel from 'views/components/map';
-import selectFeatureLayersFactory from 'views/components/cards/select-feature-layers';
-import geojsonDatatype from 'views/components/datatypes/geojson-feature-collection';
-import externalUtils from 'utils/map-filter-utils';
-
-// Common projected coordinate systems used in BC/Western Canada.
-//
-// Reference:
-//     BC FSP Electronic Submission Format, Data Types Overview
-//         - (www.for.gov.bc.ca/his/fsp/webhelp/FSP/Online_Tech_Specs/PDFs/FSP_ESF_2-6_Overview__Data_Types.pdf)
-//     Proj4 strings sourced from epsg.io.
-//
-// These are registered with proj4 so we can transform coordinates when a
-// user uploads a bare .shp file without an accompanying .prj. When a .prj
-// is provided it is passed directly to shpjs which handles reprojection
-// automatically.
-var PROJECTIONS = {
-    WGS84: 'EPSG:4326',
-    BC_ALBERS: 'EPSG:3005',
-    NAD83_UTM_7N: 'EPSG:26907',
-    NAD83_UTM_8N: 'EPSG:26908',
-    NAD83_UTM_9N: 'EPSG:26909',
-    NAD83_UTM_10N: 'EPSG:26910',
-    NAD83_UTM_11N: 'EPSG:26911',
-    WGS84_UTM_7N: 'EPSG:32607',
-    WGS84_UTM_8N: 'EPSG:32608',
-    WGS84_UTM_9N: 'EPSG:32609',
-    WGS84_UTM_10N: 'EPSG:32610',
-    WGS84_UTM_11N: 'EPSG:32611',
-};
-
-proj4.defs(
-    PROJECTIONS.BC_ALBERS,
-    '+proj=aea +lat_1=50 +lat_2=58.5 +lat_0=45 +lon_0=-126 +x_0=1000000 +y_0=0 +datum=NAD83 +units=m +no_defs',
-);
-proj4.defs(
-    PROJECTIONS.NAD83_UTM_7N,
-    '+proj=utm +zone=7 +datum=NAD83 +units=m +no_defs',
-);
-proj4.defs(
-    PROJECTIONS.NAD83_UTM_8N,
-    '+proj=utm +zone=8 +datum=NAD83 +units=m +no_defs',
-);
-proj4.defs(
-    PROJECTIONS.NAD83_UTM_9N,
-    '+proj=utm +zone=9 +datum=NAD83 +units=m +no_defs',
-);
-proj4.defs(
-    PROJECTIONS.NAD83_UTM_10N,
-    '+proj=utm +zone=10 +datum=NAD83 +units=m +no_defs',
-);
-proj4.defs(
-    PROJECTIONS.NAD83_UTM_11N,
-    '+proj=utm +zone=11 +datum=NAD83 +units=m +no_defs',
-);
-proj4.defs(
-    PROJECTIONS.WGS84_UTM_7N,
-    '+proj=utm +zone=7 +datum=WGS84 +units=m +no_defs',
-);
-proj4.defs(
-    PROJECTIONS.WGS84_UTM_8N,
-    '+proj=utm +zone=8 +datum=WGS84 +units=m +no_defs',
-);
-proj4.defs(
-    PROJECTIONS.WGS84_UTM_9N,
-    '+proj=utm +zone=9 +datum=WGS84 +units=m +no_defs',
-);
-proj4.defs(
-    PROJECTIONS.WGS84_UTM_10N,
-    '+proj=utm +zone=10 +datum=WGS84 +units=m +no_defs',
-);
-proj4.defs(
-    PROJECTIONS.WGS84_UTM_11N,
-    '+proj=utm +zone=11 +datum=WGS84 +units=m +no_defs',
-);
-
-// Check whether any coordinates in a FeatureCollection fall outside valid
-// WGS84 lng/lat bounds, which indicates the data is still in a projected
-// coordinate system and needs reprojection before Mapbox can display it.
-var needsReprojection = function (geoJSON) {
-    var checked = 0;
-    var outOfBounds = 0;
-    var walkCoords = function (coords) {
-        if (typeof coords[0] === 'number') {
-            checked++;
-            if (
-                coords[0] < -180 ||
-                coords[0] > 180 ||
-                coords[1] < -90 ||
-                coords[1] > 90
-            ) {
-                outOfBounds++;
-            }
-            return;
-        }
-        for (var i = 0; i < coords.length; i++) {
-            walkCoords(coords[i]);
-        }
-    };
-    if (geoJSON && geoJSON.features) {
-        for (var i = 0; i < geoJSON.features.length; i++) {
-            var geom = geoJSON.features[i].geometry;
-            if (geom && geom.coordinates) {
-                walkCoords(geom.coordinates);
-            }
-        }
-    }
-    return checked > 0 && outOfBounds / checked > 0.5;
-};
-
-// Transform all coordinates in a FeatureCollection in-place from sourceCRS
-// to WGS84. It is used as a fallback when shpjs could not reproject (i.e., no
-// .prj was available).
-var reprojectGeoJSON = function (geoJSON, sourceCRS) {
-    var transformCoords = function (coords) {
-        if (typeof coords[0] === 'number') {
-            var transformed = proj4(sourceCRS, PROJECTIONS.WGS84, [
-                coords[0],
-                coords[1],
-            ]);
-            coords[0] = transformed[0];
-            coords[1] = transformed[1];
-            return;
-        }
-        for (var i = 0; i < coords.length; i++) {
-            transformCoords(coords[i]);
-        }
-    };
-    if (geoJSON && geoJSON.features) {
-        for (var i = 0; i < geoJSON.features.length; i++) {
-            var geom = geoJSON.features[i].geometry;
-            if (geom && geom.coordinates) {
-                transformCoords(geom.coordinates);
-            }
-        }
-    }
-    return geoJSON;
-};
-
-// Attempt to guess the source projection from coordinate ranges when no .prj
-// file is available. This is specific to BC/Western Canada — BC Albers
-// (EPSG:3005) coordinates have large x values around 1,000,000 and y values
-// under ~1,200,000, while UTM coordinates have y values in the 5–7 million
-// range. It defaults to EPSG:3005 (BC Albers) as it is the most common
-// projection used by the BC government.
-var guessProjectionFromCoords = function (geoJSON) {
-    var sample = null;
-    if (geoJSON && geoJSON.features && geoJSON.features.length > 0) {
-        var geom = geoJSON.features[0].geometry;
-        if (geom && geom.coordinates) {
-            var coords = geom.coordinates;
-            while (Array.isArray(coords[0])) {
-                coords = coords[0];
-            }
-            sample = coords;
-        }
-    }
-    if (!sample) return PROJECTIONS.BC_ALBERS;
-    var x = sample[0];
-    var y = sample[1];
-    if (x > 200000 && x < 1900000 && y > 0 && y < 1200000) {
-        return PROJECTIONS.BC_ALBERS;
-    }
-    if (x > 100000 && x < 900000 && y > 5000000 && y < 7000000) {
-        if (x < 500000) {
-            return PROJECTIONS.NAD83_UTM_10N;
-        }
-        return PROJECTIONS.NAD83_UTM_9N;
-    }
-    return PROJECTIONS.BC_ALBERS;
-};
+import $ from "jquery";
+import _ from "underscore";
+import ko from "knockout";
+import koMapping from "knockout-mapping";
+import slick from "slick";
+import arches from "arches";
+import MapReportViewModel from "viewmodels/map-report";
+import chosen from "bindings/chosen";
+import uuid from "uuid";
+import geojsonExtent from "geojson-extent";
+import geojsonhint from "geojsonhint";
+import { kml } from "togeojson";
+import shp from "shpjsesm";
+import proj4 from "proj4";
+import MapboxDraw from "mapbox-gl-draw";
+import MapComponentViewModel from "views/components/map";
+import selectFeatureLayersFactory from "views/components/cards/select-feature-layers";
+import geojsonDatatype from "views/components/datatypes/geojson-feature-collection";
+import externalUtils from "utils/map-filter-utils";
+import projectionTools from "utils/map-projection-tools";
 
 var MapEditorViewModel = function (params) {
     var self = this;
     var padding = 40;
     var drawFeatures;
 
-    var resourceId = params.tile ? params.tile.resourceinstance_id : '';
+    var resourceId = params.tile ? params.tile.resourceinstance_id : "";
     if (this.widgets === undefined) {
         // could be [], so checking specifically for undefined
         this.widgets = params.widgets || [];
     }
 
     this.geojsonWidgets = this.widgets.filter(function (widget) {
-        return widget.datatype.datatype === 'geojson-feature-collection';
+        return widget.datatype.datatype === "geojson-feature-collection";
     });
     this.newNodeId = null;
     this.featureLookup = {};
@@ -209,12 +43,12 @@ var MapEditorViewModel = function (params) {
     this.drawAvailable = ko.observable(false);
     this.bufferNodeId = ko.observable();
     this.bufferDistance = ko.observable(0);
-    this.bufferUnits = ko.observable('m');
+    this.bufferUnits = ko.observable("m");
     this.bufferResult = ko.observable();
     this.bufferAddNew = ko.observable(false);
     this.allowAddNew =
         this.card && this.card.canAdd() && this.tile !== this.card.newTile;
-    this.selectText = ko.observable('Copy geometry');
+    this.selectText = ko.observable("Copy geometry");
 
     var selectSource = this.selectSource();
     var selectSourceLayer = this.selectSourceLayer();
@@ -230,8 +64,8 @@ var MapEditorViewModel = function (params) {
             selectFeatureLayers.forEach(function (layer) {
                 map.setLayoutProperty(
                     layer.id,
-                    'visibility',
-                    visibility ? 'visible' : 'none',
+                    "visibility",
+                    visibility ? "visible" : "none",
                 );
             });
         }
@@ -260,10 +94,10 @@ var MapEditorViewModel = function (params) {
     this.selectSourceLayer.subscribe(updateSelectLayers);
 
     this.setDrawTool = function (tool) {
-        var showSelectLayers = tool === 'select_feature';
+        var showSelectLayers = tool === "select_feature";
         self.setSelectLayersVisibility(showSelectLayers);
         if (showSelectLayers) {
-            self.draw.changeMode('simple_select');
+            self.draw.changeMode("simple_select");
             self.selectedFeatureIds([]);
         } else {
             if (tool) {
@@ -286,9 +120,9 @@ var MapEditorViewModel = function (params) {
         };
         self.featureLookup[id].selectedTool.subscribe(function (tool) {
             if (self.draw) {
-                if (tool === '') {
+                if (tool === "") {
                     self.draw.trash();
-                    self.draw.changeMode('simple_select');
+                    self.draw.changeMode("simple_select");
                 } else if (tool) {
                     _.each(self.featureLookup, function (value, key) {
                         if (key !== id) {
@@ -324,7 +158,7 @@ var MapEditorViewModel = function (params) {
             });
             if (ko.isObservable(self.tile.data[id])) {
                 self.tile.data[id]({
-                    type: 'FeatureCollection',
+                    type: "FeatureCollection",
                     features: features,
                 });
             } else {
@@ -357,7 +191,7 @@ var MapEditorViewModel = function (params) {
     if (drawFeatures.length > 0) {
         params.usePosition = false;
         params.bounds = geojsonExtent({
-            type: 'FeatureCollection',
+            type: "FeatureCollection",
             features: drawFeatures,
         });
         params.fitBoundsOptions = {
@@ -370,13 +204,13 @@ var MapEditorViewModel = function (params) {
         };
     }
 
-    params.activeTab = 'editor';
+    params.activeTab = "editor";
     params.sources = Object.assign(
         {
-            'geojson-editor-data': {
-                type: 'geojson',
+            "geojson-editor-data": {
+                type: "geojson",
                 data: {
-                    type: 'FeatureCollection',
+                    type: "FeatureCollection",
                     features: [],
                 },
             },
@@ -389,78 +223,78 @@ var MapEditorViewModel = function (params) {
     }
     var geojsonLayers = [
         {
-            id: 'geojson-editor-polygon-fill',
-            type: 'fill',
-            filter: ['==', '$type', 'Polygon'],
+            id: "geojson-editor-polygon-fill",
+            type: "fill",
+            filter: ["==", "$type", "Polygon"],
             paint: {
-                'fill-color': '#3bb2d0',
-                'fill-outline-color': '#3bb2d0',
-                'fill-opacity': 0.1,
+                "fill-color": "#3bb2d0",
+                "fill-outline-color": "#3bb2d0",
+                "fill-opacity": 0.1,
             },
-            source: 'geojson-editor-data',
+            source: "geojson-editor-data",
         },
         {
-            id: 'geojson-editor-polygon-stroke-base',
-            type: 'line',
-            filter: ['==', '$type', 'Polygon'],
+            id: "geojson-editor-polygon-stroke-base",
+            type: "line",
+            filter: ["==", "$type", "Polygon"],
             layout: {
-                'line-cap': 'round',
-                'line-join': 'round',
+                "line-cap": "round",
+                "line-join": "round",
             },
             paint: {
-                'line-color': '#fff',
-                'line-width': 4,
+                "line-color": "#fff",
+                "line-width": 4,
             },
-            source: 'geojson-editor-data',
+            source: "geojson-editor-data",
         },
         {
-            id: 'geojson-editor-polygon-stroke',
-            type: 'line',
-            filter: ['==', '$type', 'Polygon'],
+            id: "geojson-editor-polygon-stroke",
+            type: "line",
+            filter: ["==", "$type", "Polygon"],
             layout: {
-                'line-cap': 'round',
-                'line-join': 'round',
+                "line-cap": "round",
+                "line-join": "round",
             },
             paint: {
-                'line-color': '#3bb2d0',
-                'line-width': 2,
+                "line-color": "#3bb2d0",
+                "line-width": 2,
             },
-            source: 'geojson-editor-data',
+            source: "geojson-editor-data",
         },
         {
-            id: 'geojson-editor-line',
-            type: 'line',
-            filter: ['==', '$type', 'LineString'],
+            id: "geojson-editor-line",
+            type: "line",
+            filter: ["==", "$type", "LineString"],
             layout: {
-                'line-cap': 'round',
-                'line-join': 'round',
+                "line-cap": "round",
+                "line-join": "round",
             },
             paint: {
-                'line-color': '#3bb2d0',
-                'line-width': 2,
+                "line-color": "#3bb2d0",
+                "line-width": 2,
             },
-            source: 'geojson-editor-data',
+            source: "geojson-editor-data",
         },
         {
-            id: 'geojson-editor-point-point-stroke',
-            type: 'circle',
-            filter: ['==', '$type', 'Point'],
+            id: "geojson-editor-point-point-stroke",
+            type: "circle",
+            filter: ["==", "$type", "Point"],
             paint: {
-                'circle-radius': 6,
-                'circle-opacity': 1,
-                'circle-color': '#fff',
+                "circle-radius": 6,
+                "circle-opacity": 1,
+                "circle-color": "#fff",
             },
-            source: 'geojson-editor-data',
+            source: "geojson-editor-data",
         },
         {
-            id: 'geojson-editor-point',
-            type: 'circle',
-            filter: ['==', '$type', 'Point'],
+            id: "geojson-editor-point",
+            type: "circle",
+            filter: ["==", "$type", "Point"],
             paint: {
-                'circle-radius': 5,
-                'circle-color': '#3bb2d0',
+                "circle-radius": 5,
+                "circle-color": "#3bb2d0",
             },
-            source: 'geojson-editor-data',
+            source: "geojson-editor-data",
         },
     ];
 
@@ -484,7 +318,7 @@ var MapEditorViewModel = function (params) {
 
     this.editFeature = function (feature) {
         if (self.draw) {
-            self.draw.changeMode('simple_select', {
+            self.draw.changeMode("simple_select", {
                 featureIds: [feature.id],
             });
             self.selectedFeatureIds([feature.id]);
@@ -508,7 +342,7 @@ var MapEditorViewModel = function (params) {
     this.fitFeatures = function (features) {
         var map = self.map();
         var bounds = geojsonExtent({
-            type: 'FeatureCollection',
+            type: "FeatureCollection",
             features: features,
         });
         var camera = map.cameraForBounds(bounds, { padding: padding });
@@ -518,11 +352,11 @@ var MapEditorViewModel = function (params) {
     this.editGeoJSON = function (features, nodeId) {
         var geoJSONString = JSON.stringify(
             {
-                type: 'FeatureCollection',
+                type: "FeatureCollection",
                 features: features,
             },
             null,
-            '   ',
+            "   ",
         );
         this.geoJSONString(geoJSONString);
         self.newNodeId = nodeId;
@@ -544,7 +378,7 @@ var MapEditorViewModel = function (params) {
             var hint = geojsonhint.hint(geoJSONString);
             var errors = [];
             hint.forEach(function (item) {
-                if (item.level !== 'message') {
+                if (item.level !== "message") {
                     errors.push(item);
                 }
             });
@@ -557,7 +391,7 @@ var MapEditorViewModel = function (params) {
             var geoJSONErrors = self.geoJSONErrors();
             if (geoJSONErrors.length === 0) return JSON.parse(geoJSONString);
             var fc = {
-                type: 'FeatureCollection',
+                type: "FeatureCollection",
                 features: [],
             };
             if (self.bufferNodeId() && self.bufferResult()) {
@@ -568,7 +402,7 @@ var MapEditorViewModel = function (params) {
         .extend({ rateLimit: 100 });
     geoJSONLayerData.subscribe(function (data) {
         var map = self.map();
-        map.getSource('geojson-editor-data').setData(data);
+        map.getSource("geojson-editor-data").setData(data);
     });
     this.updateGeoJSON = function () {
         if (self.geoJSONErrors().length === 0) {
@@ -608,20 +442,20 @@ var MapEditorViewModel = function (params) {
         });
         map.addControl(self.draw);
         self.draw.set({
-            type: 'FeatureCollection',
+            type: "FeatureCollection",
             features: getDrawFeatures(),
         });
-        map.on('draw.create', function (e) {
+        map.on("draw.create", function (e) {
             e.features.forEach(function (feature) {
                 self.draw.setFeatureProperty(
                     feature.id,
-                    'nodeId',
+                    "nodeId",
                     self.newNodeId,
                 );
             });
             self.updateTiles();
         });
-        map.on('draw.update', function () {
+        map.on("draw.update", function () {
             self.updateTiles();
             if (self.coordinateEditing()) {
                 var editingFeature = self.draw.getSelected().features[0];
@@ -630,13 +464,13 @@ var MapEditorViewModel = function (params) {
             }
             if (self.bufferNodeId()) self.updateBufferFeature();
         });
-        map.on('draw.delete', self.updateTiles);
-        map.on('draw.modechange', function (e) {
+        map.on("draw.delete", self.updateTiles);
+        map.on("draw.modechange", function (e) {
             self.updateTiles();
             self.setSelectLayersVisibility(false);
             map.draw_mode = e.mode;
         });
-        map.on('draw.selectionchange', function (e) {
+        map.on("draw.selectionchange", function (e) {
             self.selectedFeatureIds(
                 e.features.map(function (feature) {
                     return feature.id;
@@ -651,16 +485,16 @@ var MapEditorViewModel = function (params) {
         });
 
         if (self.form)
-            self.form.on('tile-reset', function () {
+            self.form.on("tile-reset", function () {
                 var style = self.map().getStyle();
                 if (style) {
                     self.draw.set({
-                        type: 'FeatureCollection',
+                        type: "FeatureCollection",
                         features: getDrawFeatures(),
                     });
                 }
                 _.each(self.featureLookup, function (value) {
-                    if (value.selectedTool()) value.selectedTool('');
+                    if (value.selectedTool()) value.selectedTool("");
                 });
             });
         if (self.draw) {
@@ -715,29 +549,29 @@ var MapEditorViewModel = function (params) {
             widget.drawTools = ko.pureComputed(function () {
                 var options = [
                     {
-                        value: '',
-                        text: '',
+                        value: "",
+                        text: "",
                     },
                 ];
                 options = options.concat(
                     ko.unwrap(widget.config.geometryTypes).map(function (type) {
                         var option = {};
                         switch (ko.unwrap(type.id)) {
-                            case 'Point':
-                                option.value = 'draw_point';
+                            case "Point":
+                                option.value = "draw_point";
                                 option.text = arches.translations.mapAddPoint;
                                 break;
-                            case 'Line':
-                                option.value = 'draw_line_string';
+                            case "Line":
+                                option.value = "draw_line_string";
                                 option.text = arches.translations.mapAddLine;
                                 break;
-                            case 'Polygon':
-                                option.value = 'draw_polygon';
+                            case "Polygon":
+                                option.value = "draw_polygon";
                                 option.text = arches.translations.mapAddPolygon;
                                 break;
-                            case 'Feature':
-                                option.value = 'select_feature';
-                                option.text = 'Select Cadastral Feature';
+                            case "Feature":
+                                option.value = "select_feature";
+                                option.text = "Select Cadastral Feature";
                                 break;
                         }
                         return option;
@@ -745,7 +579,7 @@ var MapEditorViewModel = function (params) {
                 );
                 if (self.selectSource()) {
                     options.push({
-                        value: 'select_feature',
+                        value: "select_feature",
                         text:
                             self.selectText() ||
                             arches.translations.mapSelectDrawing,
@@ -759,7 +593,7 @@ var MapEditorViewModel = function (params) {
 
     this.isFeatureClickable = function (feature) {
         var tool = self.selectedTool();
-        if (tool && tool !== 'select_feature') return false;
+        if (tool && tool !== "select_feature") return false;
         return (
             feature.properties.resourceinstanceid || self.isSelectable(feature)
         );
@@ -784,7 +618,7 @@ var MapEditorViewModel = function (params) {
         });
         self.updateTiles();
         if (self.popup) self.popup.remove();
-        self.draw.changeMode('simple_select', {
+        self.draw.changeMode("simple_select", {
             featureIds: featureIds,
         });
         self.selectedFeatureIds(featureIds);
@@ -797,7 +631,7 @@ var MapEditorViewModel = function (params) {
         try {
             let geometry = feature.toJSON().geometry;
             var newFeature = {
-                type: 'Feature',
+                type: "Feature",
                 properties: {},
                 geometry: geometry,
             };
@@ -810,7 +644,7 @@ var MapEditorViewModel = function (params) {
     };
 
     self.showSelectFeatureAsSource = function (feature) {
-        if (self.selectedTool && self.selectedTool() === 'select_feature')
+        if (self.selectedTool && self.selectedTool() === "select_feature")
             return true;
         return false;
     };
@@ -819,7 +653,7 @@ var MapEditorViewModel = function (params) {
         console.log(feature);
         var myfeature = externalUtils.getFeatureFromWFS(
             feature,
-            'WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW',
+            "WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW",
         );
         addSelectFeatures([myfeature]);
     };
@@ -828,7 +662,7 @@ var MapEditorViewModel = function (params) {
         var hint = geojsonhint.hint(geoJSONString);
         var errors = [];
         hint.forEach(function (item) {
-            if (item.level !== 'message') {
+            if (item.level !== "message") {
                 errors.push(item);
             }
         });
@@ -862,8 +696,8 @@ var MapEditorViewModel = function (params) {
 
         // First pass: read the .prj file if one was included alongside the .shp
         for (var i = 0; i < files.length; i++) {
-            var extension = files[i].name.split('.').pop().toLowerCase();
-            if (extension === 'prj') {
+            var extension = files[i].name.split(".").pop().toLowerCase();
+            if (extension === "prj") {
                 (function (file) {
                     promises.push(
                         new Promise(function (resolve) {
@@ -884,63 +718,63 @@ var MapEditorViewModel = function (params) {
         // so they don't produce "unsupported file" errors when users drag
         // in the full shapefile bundle.
         for (var i = 0; i < files.length; i++) {
-            var extension = files[i].name.split('.').pop().toLowerCase();
+            var extension = files[i].name.split(".").pop().toLowerCase();
             if (
                 ![
-                    'kml',
-                    'json',
-                    'geojson',
-                    'shp',
-                    'zip',
-                    'prj',
-                    'dbf',
-                    'shx',
-                    'cpg',
-                    'qpj',
+                    "kml",
+                    "json",
+                    "geojson",
+                    "shp",
+                    "zip",
+                    "prj",
+                    "dbf",
+                    "shx",
+                    "cpg",
+                    "qpj",
                 ].includes(extension)
             ) {
                 errors.push({
                     message: 'File unsupported: "' + files[i].name + '"',
                 });
             } else if (
-                ['kml', 'json', 'geojson', 'shp', 'zip'].includes(extension)
+                ["kml", "json", "geojson", "shp", "zip"].includes(extension)
             ) {
                 promises.push(
                     new Promise(function (resolve) {
                         var file = files[i];
                         var extension = file.name
-                            .split('.')
+                            .split(".")
                             .pop()
                             .toLowerCase();
                         var reader = new window.FileReader();
                         reader.onload = function (e) {
                             var geoJSON;
-                            if (['json', 'geojson'].includes(extension))
+                            if (["json", "geojson"].includes(extension))
                                 geoJSON = JSON.parse(e.target.result);
-                            else if (extension === 'kml')
+                            else if (extension === "kml")
                                 geoJSON = kml(
                                     new window.DOMParser().parseFromString(
                                         e.target.result,
-                                        'text/xml',
+                                        "text/xml",
                                     ),
                                 );
                             // Pass the .prj string to shpjs when available so
                             // it can handle reprojection automatically.
-                            else if (extension === 'shp')
+                            else if (extension === "shp")
                                 shp({
                                     shp: e.target.result,
                                     prj: prjString,
                                 }).then((parsedShp) => {
                                     resolve(parsedShp);
                                 });
-                            else if (extension === 'zip')
+                            else if (extension === "zip")
                                 shp(e.target.result).then(function (parsedZip) {
                                     resolve(parsedZip);
                                 });
-                            if (!['shp', 'zip'].includes(extension))
+                            if (!["shp", "zip"].includes(extension))
                                 resolve(geoJSON);
                         };
-                        if (['shp', 'zip'].includes(extension))
+                        if (["shp", "zip"].includes(extension))
                             reader.readAsArrayBuffer(file);
                         else reader.readAsText(file);
                     }),
@@ -949,7 +783,7 @@ var MapEditorViewModel = function (params) {
         }
         Promise.all(promises).then(function (results) {
             var geoJSON = {
-                type: 'FeatureCollection',
+                type: "FeatureCollection",
                 features: results.reduce(function (features, geoJSON) {
                     if (geoJSON && geoJSON.features) {
                         features = features.concat(geoJSON.features);
@@ -962,14 +796,14 @@ var MapEditorViewModel = function (params) {
             // WGS84 bounds (e.g., bare .shp with no .prj or shpjs could not
             // parse the .prj), attempt to reproject using coordinate-range
             // heuristics for common BC/Western Canada projections.
-            if (needsReprojection(geoJSON)) {
-                var sourceCRS = guessProjectionFromCoords(geoJSON);
+            if (projectionTools.needsReprojection(geoJSON)) {
+                var sourceCRS = projectionTools.guessProjectionFromCoords(geoJSON);
                 console.warn(
-                    'Shapefile coordinates are not in WGS84. ' +
-                        'Attempting reprojection from: ' +
+                    "Shapefile coordinates are not in WGS84. " +
+                        "Attempting reprojection from: " +
                         sourceCRS,
                 );
-                reprojectGeoJSON(geoJSON, sourceCRS);
+                projectionTools.reprojectGeoJSON(geoJSON, sourceCRS);
             }
 
             errors = errors.concat(
@@ -991,24 +825,24 @@ var MapEditorViewModel = function (params) {
     self.dropZoneOverHandler = function (data, e) {
         e.stopPropagation();
         e.preventDefault();
-        e.originalEvent.dataTransfer.dropEffect = 'copy';
+        e.originalEvent.dataTransfer.dropEffect = "copy";
     };
 
     self.dropZoneClickHandler = function (data, e) {
         var fileInput = e.target.parentNode.parentNode.querySelector(
-            '.hidden-file-input input',
+            ".hidden-file-input input",
         );
-        var event = window.document.createEvent('MouseEvents');
-        event.initEvent('click', true, false);
+        var event = window.document.createEvent("MouseEvents");
+        event.initEvent("click", true, false);
         fileInput.dispatchEvent(event);
     };
 
     self.dropZoneEnterHandler = function (data, e) {
-        e.target.classList.add('drag-hover');
+        e.target.classList.add("drag-hover");
     };
 
     self.dropZoneLeaveHandler = function (data, e) {
-        e.target.classList.remove('drag-hover');
+        e.target.classList.remove("drag-hover");
     };
 
     self.dropZoneFileSelected = function (data, e) {
@@ -1038,16 +872,16 @@ var MapEditorViewModel = function (params) {
                 var drawFeatures = getDrawFeatures();
                 drawFeatures.forEach(function (feature) {
                     if (feature.id === selectedFeatureId) {
-                        if (feature.geometry.type === 'Polygon') {
+                        if (feature.geometry.type === "Polygon") {
                             rawCoordinates.push(rawCoordinates[0]);
                             feature.geometry.coordinates[0] = rawCoordinates;
-                        } else if (feature.geometry.type === 'Point')
+                        } else if (feature.geometry.type === "Point")
                             feature.geometry.coordinates = rawCoordinates[0];
                         else feature.geometry.coordinates = rawCoordinates;
                     }
                 });
                 self.draw.set({
-                    type: 'FeatureCollection',
+                    type: "FeatureCollection",
                     features: drawFeatures,
                 });
                 self.updateTiles();
@@ -1055,11 +889,11 @@ var MapEditorViewModel = function (params) {
                 var coordinates = [];
                 var geomType = self.coordinateGeomType();
                 switch (geomType) {
-                    case 'Polygon':
+                    case "Polygon":
                         rawCoordinates.push(rawCoordinates[0]);
                         coordinates = [rawCoordinates];
                         break;
-                    case 'Point':
+                    case "Point":
                         coordinates = rawCoordinates[0];
                         break;
                     default:
@@ -1068,7 +902,7 @@ var MapEditorViewModel = function (params) {
                 }
                 addSelectFeatures([
                     {
-                        type: 'Feature',
+                        type: "Feature",
                         geometry: {
                             type: geomType,
                             coordinates: coordinates,
@@ -1100,7 +934,7 @@ var MapEditorViewModel = function (params) {
         var newCoords = [ko.observable(coords[0]), ko.observable(coords[1])];
         newCoords.forEach(function (value) {
             value.subscribe(function (newValue) {
-                if ([undefined, null, ''].includes(newValue)) value(0);
+                if ([undefined, null, ""].includes(newValue)) value(0);
             });
         });
         return newCoords;
@@ -1115,7 +949,7 @@ var MapEditorViewModel = function (params) {
     });
     var updateCoordinatesFromFeature = function (feature) {
         var sourceCoordinates = [];
-        if (feature.geometry.type === 'Polygon') {
+        if (feature.geometry.type === "Polygon") {
             sourceCoordinates = [];
             for (
                 var i = 0;
@@ -1124,7 +958,7 @@ var MapEditorViewModel = function (params) {
             ) {
                 sourceCoordinates.push(feature.geometry.coordinates[0][i]);
             }
-        } else if (feature.geometry.type === 'Point')
+        } else if (feature.geometry.type === "Point")
             sourceCoordinates = [feature.geometry.coordinates];
         else sourceCoordinates = feature.geometry.coordinates;
         self.coordinateGeomType(feature.geometry.type);
@@ -1160,14 +994,14 @@ var MapEditorViewModel = function (params) {
         self.coordinateGeomType(null);
         var selectedTool = self.selectedTool();
         switch (selectedTool) {
-            case 'draw_point':
-                self.coordinateGeomType('Point');
+            case "draw_point":
+                self.coordinateGeomType("Point");
                 break;
-            case 'draw_line_string':
-                self.coordinateGeomType('LineString');
+            case "draw_line_string":
+                self.coordinateGeomType("LineString");
                 break;
-            case 'draw_polygon':
-                self.coordinateGeomType('Polygon');
+            case "draw_polygon":
+                self.coordinateGeomType("Polygon");
                 break;
             default:
                 break;
@@ -1191,7 +1025,7 @@ var MapEditorViewModel = function (params) {
             if (selectedTool) {
                 self.draw.trash();
             }
-            self.draw.changeMode('simple_select', selectConfig);
+            self.draw.changeMode("simple_select", selectConfig);
             _.each(self.featureLookup, function (value) {
                 value.selectedTool(null);
             });
@@ -1200,20 +1034,20 @@ var MapEditorViewModel = function (params) {
     self.hideNewCoordinates = ko.computed(function () {
         var geomType = self.coordinateGeomType();
         var coordCount = self.coordinates().length;
-        return geomType === 'Point' && coordCount > 0;
+        return geomType === "Point" && coordCount > 0;
     });
 
     self.minCoordinates = ko.computed(function () {
         var geomType = self.coordinateGeomType();
         var minCoordinates;
         switch (geomType) {
-            case 'Point':
+            case "Point":
                 minCoordinates = 1;
                 break;
-            case 'LineString':
+            case "LineString":
                 minCoordinates = 2;
                 break;
-            case 'Polygon':
+            case "Polygon":
                 minCoordinates = 3;
                 break;
             default:
@@ -1234,12 +1068,12 @@ var MapEditorViewModel = function (params) {
         var featureId = self.selectedFeatureIds()[0];
         if (featureId) {
             var feature = self.draw.get(featureId);
-            return ['Point', 'LineString', 'Polygon'].includes(
+            return ["Point", "LineString", "Polygon"].includes(
                 feature.geometry.type,
             );
         } else {
             var selectedTool = self.selectedTool();
-            return ['draw_point', 'draw_line_string', 'draw_polygon'].includes(
+            return ["draw_point", "draw_line_string", "draw_polygon"].includes(
                 selectedTool,
             );
         }
@@ -1285,7 +1119,7 @@ var MapEditorViewModel = function (params) {
             window
                 .fetch(
                     arches.urls.buffer +
-                        '?filter=' +
+                        "?filter=" +
                         JSON.stringify(bufferParams),
                 )
                 .then(function (response) {
@@ -1296,7 +1130,7 @@ var MapEditorViewModel = function (params) {
                 .then(function (json) {
                     var bufferFeature = getBufferFeature();
                     self.bufferResult({
-                        type: 'Feature',
+                        type: "Feature",
                         id: uuid.generate(),
                         geometry: json,
                         properties: {
@@ -1320,7 +1154,7 @@ var MapEditorViewModel = function (params) {
             var addBufferResultAsNew = function () {
                 var updateNewTile = self.card.selected.subscribe(function () {
                     var fc = {
-                        type: 'FeatureCollection',
+                        type: "FeatureCollection",
                         features: [bufferResult],
                     };
                     self.card.getNewTile().data[nodeId](fc);


### PR DESCRIPTION
I have tested the following:
- The full .zip (with .prj inside)
- A bare .shp file
- A bare .shp + .prj dragged together
- A bare .shp + .prj + .dbf + .shx + .cpg dragged together
- A bare .kml file

based on the "Sample Files" provided in SharePoint. 

I can remove some of the other Coordinate Reference Systems if they're not needed, but thought I'd attempt to cover the ones listed in the BC FSP Electronic Submission Format spec. I also ran prettier. Sorry about the formatting changes in the diff.

closes #1240