### PR TITLE
Sync Release 1 -> Release 2

### DIFF
--- a/bcap/templates/base-root.htm
+++ b/bcap/templates/base-root.htm
@@ -89,8 +89,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endblock arches_modules %}
 
 {% if main_script %}
-    {{ USE_VITE }}
-
     {# Always: the reusable KO↔Vue bridge #}
     <script>
         // This needs to run before the bridge for early firing if we're not using vite


### PR DESCRIPTION
closes 

https://github.com/bcgov/nr-bcap/issues/1423

Other two changes were settings black change (already in another PR)

and this one:
<img width="674" height="56" alt="image" src="https://github.com/user-attachments/assets/d4da25b7-84d5-4e31-bc0a-0b19ac5a726c" />

Brett says we'll have to do it another way