### PR TITLE
Separate S3 file upload paths for widgets

### DIFF
--- a/bcap/tests/test_storage_filename_generator.py
+++ b/bcap/tests/test_storage_filename_generator.py
@@ -1,22 +1,10 @@
 import os
-import sys
-import types
-from unittest import TestCase
 from unittest.mock import MagicMock
 
-# Stub arches before importing so Django's app registry is never touched.
-for _name in [
-    "arches",
-    "arches.app",
-    "arches.app.models",
-    "arches.app.models.models",
-    "arches.app.datatypes",
-    "arches.app.datatypes.datatypes",
-]:
-    sys.modules.setdefault(_name, types.ModuleType(_name))
+from django.test import TestCase
 
-from bcap.util import storage_filename_generator  # noqa: E402
-from bcap.util.storage_filename_generator import generate_filename  # noqa: E402
+from bcap.util import storage_filename_generator
+from bcap.util.storage_filename_generator import generate_filename
 
 
 class TestGenerateFilename(TestCase):

--- a/bcap/tests/test_storage_filename_generator.py
+++ b/bcap/tests/test_storage_filename_generator.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+# Stub arches before importing so Django's app registry is never touched.
+for _name in [
+    "arches",
+    "arches.app",
+    "arches.app.models",
+    "arches.app.models.models",
+    "arches.app.datatypes",
+    "arches.app.datatypes.datatypes",
+]:
+    sys.modules.setdefault(_name, types.ModuleType(_name))
+
+from bcap.util import storage_filename_generator  # noqa: E402
+from bcap.util.storage_filename_generator import generate_filename  # noqa: E402
+
+
+class TestGenerateFilename(TestCase):
+    def setUp(self):
+        for attr in ("borden_number_node", "borden_number_datatype"):
+            if hasattr(generate_filename, attr):
+                delattr(generate_filename, attr)
+
+        mock_node = MagicMock()
+        mock_node.datatype = "string"
+
+        self.mock_datatype = MagicMock()
+        self.mock_models = MagicMock()
+        self.mock_models.Node.objects.filter.return_value.first.return_value = mock_node
+        self.mock_models.TileModel.objects.filter.return_value.first.return_value = None
+
+        self.mock_datatypes = MagicMock()
+        self.mock_datatypes.datatypes.DataTypeFactory.return_value.get_instance.return_value = (
+            self.mock_datatype
+        )
+
+        storage_filename_generator.models = self.mock_models
+        storage_filename_generator.datatypes = self.mock_datatypes
+
+    def _instance(
+        self, slug="my-graph", resource_id="rid", node_alias="site_photograph"
+    ):
+        inst = MagicMock()
+        inst.tile.resourceinstance.graph.slug = slug
+        inst.tile.resourceinstance.resourceinstanceid = resource_id
+        inst.tile.nodegroup.grouping_node.alias = node_alias
+        return inst
+
+    def test_borden_number_splits_into_path_segments(self):
+        self.mock_datatype.get_display_value.return_value = "EeRm-123"
+        self.mock_models.TileModel.objects.filter.return_value.first.return_value = (
+            MagicMock()
+        )
+
+        result = generate_filename(self._instance(), "photo.jpg")
+
+        self.assertEqual(
+            result,
+            os.path.join("my-graph", "EeRm", "123", "photo__site_photograph.jpg"),
+        )
+
+    def test_no_borden_tile_uses_resource_id(self):
+        result = generate_filename(self._instance(), "report.pdf")
+
+        self.assertEqual(
+            result, os.path.join("my-graph", "rid", "report__site_photograph.pdf")
+        )
+
+    def test_no_graph_slug_uses_system_settings(self):
+        inst = self._instance(slug="")
+
+        result = generate_filename(inst, "data.csv")
+
+        self.assertTrue(result.startswith("system_settings"))

--- a/bcap/tests/test_storage_filename_generator.py
+++ b/bcap/tests/test_storage_filename_generator.py
@@ -48,14 +48,14 @@ class TestGenerateFilename(TestCase):
 
         self.assertEqual(
             result,
-            os.path.join("my-graph", "EeRm", "123", "photo__site_photograph.jpg"),
+            os.path.join("my-graph", "EeRm", "123", "site_photograph", "photo.jpg"),
         )
 
     def test_no_borden_tile_uses_resource_id(self):
         result = generate_filename(self._instance(), "report.pdf")
 
         self.assertEqual(
-            result, os.path.join("my-graph", "rid", "report__site_photograph.pdf")
+            result, os.path.join("my-graph", "rid", "site_photograph", "report.pdf")
         )
 
     def test_no_graph_slug_uses_system_settings(self):

--- a/bcap/tests/test_storage_filename_generator.py
+++ b/bcap/tests/test_storage_filename_generator.py
@@ -29,13 +29,11 @@ class TestGenerateFilename(TestCase):
         storage_filename_generator.models = self.mock_models
         storage_filename_generator.datatypes = self.mock_datatypes
 
-    def _instance(
-        self, slug="my-graph", resource_id="rid", node_alias="site_photograph"
-    ):
+    def _instance(self, slug="my-graph", resource_id="rid", tile_id="tile-uuid"):
         inst = MagicMock()
         inst.tile.resourceinstance.graph.slug = slug
         inst.tile.resourceinstance.resourceinstanceid = resource_id
-        inst.tile.nodegroup.grouping_node.alias = node_alias
+        inst.tile.tileid = tile_id
         return inst
 
     def test_borden_number_splits_into_path_segments(self):
@@ -48,14 +46,14 @@ class TestGenerateFilename(TestCase):
 
         self.assertEqual(
             result,
-            os.path.join("my-graph", "EeRm", "123", "site_photograph", "photo.jpg"),
+            os.path.join("my-graph", "EeRm", "123", "photo-tile-uuid.jpg"),
         )
 
     def test_no_borden_tile_uses_resource_id(self):
         result = generate_filename(self._instance(), "report.pdf")
 
         self.assertEqual(
-            result, os.path.join("my-graph", "rid", "site_photograph", "report.pdf")
+            result, os.path.join("my-graph", "rid", "report-tile-uuid.pdf")
         )
 
     def test_no_graph_slug_uses_system_settings(self):

--- a/bcap/util/storage_filename_generator.py
+++ b/bcap/util/storage_filename_generator.py
@@ -1,6 +1,9 @@
+import logging
 import os
 from arches.app.models import models
 from arches.app import datatypes
+
+logger = logging.getLogger(__name__)
 
 borden_number_node = None
 datatype_factory = None
@@ -8,18 +11,31 @@ borden_number_datatype = None
 
 
 def generate_filename(instance, filename):
-    # print("Instance: %s (%s)" % (instance, type(instance)))
-    # print("File ID: %s (%s)" % (instance.fileid, type(instance.fileid)))
-    # print("Tile: %s (%s)" % (instance.tile, type(instance.tile)))
-    # print("ResourceInstance: %s (%s)" % (instance.tile.resourceinstance, type(instance.tile.resourceinstance)))
-    # print("GraphID: %s (%s)" % (instance.tile.resourceinstance.graph.graphid, type(instance.tile.resourceinstance.graph.graphid)))
-    # print("Graph Slug: %s (%s)" % (instance.tile.resourceinstance.graph.slug, type(instance.tile.resourceinstance.graph.graphid)))
-    # return os.sep.join(["images",str(instance.tile.resourceinstance.resourceinstanceid), f"%s__%s" % (instance.fileid, filename)])
+    logger.debug("Instance: %s (%s)", instance, type(instance))
+    logger.debug("File ID: %s (%s)", instance.fileid, type(instance.fileid))
+    logger.debug("Tile: %s (%s)", instance.tile, type(instance.tile))
+    logger.debug(
+        "ResourceInstance: %s (%s)",
+        instance.tile.resourceinstance,
+        type(instance.tile.resourceinstance),
+    )
+    logger.debug(
+        "GraphID: %s (%s)",
+        instance.tile.resourceinstance.graph.graphid,
+        type(instance.tile.resourceinstance.graph.graphid),
+    )
+    logger.debug(
+        "Graph Slug: %s (%s)",
+        instance.tile.resourceinstance.graph.slug,
+        type(instance.tile.resourceinstance.graph.graphid),
+    )
     if not hasattr(generate_filename, "borden_number_node"):
         generate_filename.borden_number_node = models.Node.objects.filter(
             alias="borden_number"
         ).first()
-        # print("Got borden number node: %s" % str(generate_filename.borden_number_node))
+        logger.debug(
+            "Got borden number node: %s", str(generate_filename.borden_number_node)
+        )
 
     if not hasattr(generate_filename, "borden_number_datatype"):
         generate_filename.borden_number_datatype = (
@@ -27,13 +43,16 @@ def generate_filename(instance, filename):
                 generate_filename.borden_number_node.datatype
             )
         )
-        # print("Got borden number datatype: %s" % str(generate_filename.borden_number_datatype))
+        logger.debug(
+            "Got borden number datatype: %s",
+            str(generate_filename.borden_number_datatype),
+        )
 
     borden_number_tile = models.TileModel.objects.filter(
         resourceinstance=instance.tile.resourceinstance,
         nodegroup=generate_filename.borden_number_node.nodegroup,
     ).first()
-    # print("Got borden number tile: %s" % str(borden_number_tile))
+    logger.debug("Got borden number tile: %s", str(borden_number_tile))
     borden_number = None
 
     paths = []
@@ -54,5 +73,12 @@ def generate_filename(instance, filename):
         if instance.tile.resourceinstance.graph.slug
         else "system_settings"
     )
-    # print("Paths: %s" % str(paths))
-    return os.path.join(graph_slug, *paths, filename)
+    logger.debug("Paths: %s", str(paths))
+    root, ext = os.path.splitext(filename)
+    path = os.path.join(
+        graph_slug,
+        *paths,
+        f"{root}__{instance.tile.nodegroup.grouping_node.alias}{ext}",
+    )
+    logger.debug("Generated filename: %s", path)
+    return path

--- a/bcap/util/storage_filename_generator.py
+++ b/bcap/util/storage_filename_generator.py
@@ -78,7 +78,8 @@ def generate_filename(instance, filename):
     path = os.path.join(
         graph_slug,
         *paths,
-        f"{root}__{instance.tile.nodegroup.grouping_node.alias}{ext}",
+        instance.tile.nodegroup.grouping_node.alias,
+        f"{root}{ext}",
     )
     logger.debug("Generated filename: %s", path)
     return path

--- a/bcap/util/storage_filename_generator.py
+++ b/bcap/util/storage_filename_generator.py
@@ -78,8 +78,7 @@ def generate_filename(instance, filename):
     path = os.path.join(
         graph_slug,
         *paths,
-        instance.tile.nodegroup.grouping_node.alias,
-        f"{root}{ext}",
+        f"{root}-{instance.tile.tileid}{ext}",
     )
     logger.debug("Generated filename: %s", path)
     return path

--- a/bcap/util/storage_filename_generator.py
+++ b/bcap/util/storage_filename_generator.py
@@ -80,5 +80,5 @@ def generate_filename(instance, filename):
         *paths,
         f"{root}-{instance.tile.tileid}{ext}",
     )
-    logger.debug("Generated filename: %s", path)
+    logger.debug("Generated filepath: %s", path)
     return path


### PR DESCRIPTION
This should support uploaded files being overwritten within their own widget and maintain seperation in different widgets with the same filenames

Helps # 4 in https://github.com/bcgov/nr-bcap/issues/1419

closes: #1439
Requires some testing before going to ready for review.