### PR TITLE
Brf/feat/1271 add publication resource model

### DIFF
--- a/bcap/functions/publication_descriptors.py
+++ b/bcap/functions/publication_descriptors.py
@@ -1,0 +1,92 @@
+from bcap.util.bcap_aliases import GraphSlugs
+from bcap.util.aliases.publication import PublicationAliases as aliases
+from bcgov_arches_common.util.bc_primary_descriptors_function import (
+    BCPrimaryDescriptorsFunction,
+)
+from bcgov_arches_common.util.graph_lookup import GraphLookup
+
+details = {
+    "functionid": "60000000-0000-0000-0000-000000001003",
+    "name": "Publication Descriptors",
+    "type": "primarydescriptors",
+    "modulename": "publication_descriptors.py",
+    "description": "Function that provides the primary descriptors for BCAP Publications",
+    "defaultconfig": {
+        "module": "bcap.functions.publication_descriptors",
+        "class_name": "PublicationDescriptors",
+        "descriptor_types": {
+            "name": {},
+            "description": {},
+            "map_popup": {},
+        },
+        "triggering_nodegroups": [],
+    },
+    "classname": "PublicationDescriptors",
+    "component": "views/components/functions/publication-descriptors",
+}
+
+
+class PublicationDescriptors(BCPrimaryDescriptorsFunction):
+    # For Name part of descriptor
+    _graph_slug = GraphSlugs.PUBLICATION
+    _graph_lookup = None
+
+    _name_nodes = [aliases.TITLE, aliases.JOURNAL_OR_VOLUME_NAME]
+    _card_nodes = [aliases.AUTHORS, aliases.PUBLICATION_TYPE]
+
+    def __init__(self):
+        super(PublicationDescriptors).__init__()
+        self._graph_lookup = GraphLookup(
+            PublicationDescriptors._graph_slug,
+            PublicationDescriptors._name_nodes + PublicationDescriptors._card_nodes,
+        )
+
+    def get_primary_descriptor_from_nodes(
+        self, resource, config, context=None, descriptor=None
+    ):
+        return_value = ""
+
+        try:
+            if descriptor == "name":
+                return self._get_name(resource)
+
+            for node_alias in self._card_nodes:
+                value = self.get_value_from_node(
+                    self._graph_lookup.get_node(node_alias),
+                    self._graph_lookup.get_datatype(node_alias),
+                    resource,
+                )
+                if value:
+                    return_value += self.format_value(
+                        self._graph_lookup.get_node(node_alias).name, value, True
+                    )
+
+            return return_value
+
+        except ValueError as e:
+            print(e, "invalid nodegroupid participating in descriptor function.")
+
+    def _get_name(self, resource):
+        parent_publication_name = ""
+
+        publication_type = self.get_value_from_node(
+            self._graph_lookup.get_node(aliases.PUBLICATION_TYPE),
+            self._graph_lookup.get_datatype(aliases.PUBLICATION_TYPE),
+            resource,
+        )
+        if publication_type == "Volume / Publication Number":
+            parent_publication_name = "%s " % self.get_value_from_node(
+                self._graph_lookup.get_node(aliases.JOURNAL_OR_VOLUME_NAME),
+                self._graph_lookup.get_datatype(aliases.JOURNAL_OR_VOLUME_NAME),
+                resource,
+            )
+
+        title = self.get_value_from_node(
+            self._graph_lookup.get_node(aliases.TITLE),
+            self._graph_lookup.get_datatype(aliases.TITLE),
+            resource,
+        )
+
+        # print("Resource: %s, Title: %s, Parent: %s" % (resource, title, parent_publication_name))
+        # This shouldn't be necessary but we have some cardinality violations
+        return parent_publication_name + str(title)

--- a/bcap/management/commands/bc_reindex_database.py
+++ b/bcap/management/commands/bc_reindex_database.py
@@ -11,6 +11,7 @@ class Command(BaseCommand):
             "lg_person",
             "local_government",
             "legislative_act",
+            "publication",
             "repository",
             "hca_permit",
             "archaeological_site",

--- a/bcap/media/js/views/components/functions/publication-descriptors.js
+++ b/bcap/media/js/views/components/functions/publication-descriptors.js
@@ -1,0 +1,125 @@
+import $ from 'jquery';
+import _ from 'underscore';
+import arches from 'arches';
+import ko from 'knockout';
+import koMapping from 'knockout-mapping';
+import FunctionViewModel from 'viewmodels/function-view-model';
+import chosen from 'bindings/chosen';
+import simpleSwitch from 'views/components/simple-switch';
+import defaultFossilsDescriptorsTemplate from 'templates/views/components/functions/publication-descriptors.htm';
+export default ko.components.register(
+    'views/components/functions/publication-descriptors',
+    {
+        viewModel: function (params) {
+            FunctionViewModel.apply(this, arguments);
+            console.log('params2' + JSON.stringify(params));
+            var nodegroups = {};
+            var sortedCards = [];
+            this.triggering_nodegroups = params.config.triggering_nodegroups;
+            //this.cards = ko.observableArray();
+            this.loading = ko.observable(false);
+            this.show_value = ko.observable(false);
+            this.first_only = ko.observable(false);
+
+            this.graph.nodes.forEach(function (card) {
+                //this.cards.push(card);
+                if (card.datatype !== 'semantic') {
+                    sortedCards.push(card);
+                    nodegroups[card.nodeid] = true;
+                }
+            }, this);
+
+            sortedCards.sort(function (a, b) {
+                if (a.name === b.name) return 0;
+                return a.name > b.name ? 1 : -1;
+            });
+            this.cards = ko.observableArray(sortedCards);
+
+            this.name = params.config.descriptor_types.name;
+            this.description = params.config.descriptor_types.description;
+            this.map_popup = params.config.descriptor_types.map_popup;
+
+            _.each(
+                [this.name, this.description, this.map_popup],
+                function (property) {
+                    if (property.nodegroup_id) {
+                        property.nodegroup_id.subscribe(function (
+                            nodegroup_id,
+                        ) {
+                            console.log('Hi');
+                            property.string_template(nodegroup_id);
+
+                            var nodes = _.filter(
+                                this.graph.nodes,
+                                function (node) {
+                                    return node.nodegroup_id === nodegroup_id;
+                                },
+                                this,
+                            );
+                            var templateFragments = [];
+                            _.each(
+                                nodes,
+                                function (node) {
+                                    templateFragments.push(
+                                        '<' + node.name + '>',
+                                    );
+                                },
+                                this,
+                            );
+
+                            var template = templateFragments.join(', ');
+                            property.string_template(template);
+                        }, this);
+                    }
+                    // if (property.card_names) {
+                    //     property.card_names.subscribe(function(card_names){
+                    //         var templateFragments = [];
+                    //         //property.string_template(card_names);
+                    //         _.each(card_names, function(card_name){
+                    //             console.log(card_name);
+                    //             var node = _.filter(this.graph.nodes, function(node){
+                    //                 return node.name === card_name;
+                    //             }, this);
+                    //             templateFragments.push('<' + node.name + '>');
+                    //         }, this);
+                    //
+                    //         /*
+                    //         var nodes = _.filter(this.graph.nodes, function(node){
+                    //             return node.nodegroup_id === nodegroup_id;
+                    //         }, this);
+                    //         _.each(nodes, function(node){
+                    //             templateFragments.push('<' + node.name + '>');
+                    //         }, this);
+                    //
+                    //         var template = templateFragments.join(', ');
+                    //         property.string_template(template);
+                    //          */
+                    //     }, this);
+                    // }
+                },
+                this,
+            );
+
+            this.reindexdb = function () {
+                this.loading(true);
+                $.ajax({
+                    type: 'POST',
+                    url: arches.urls.reindex,
+                    context: this,
+                    data: JSON.stringify({ graphids: [this.graph.graphid] }),
+                    error: function () {
+                        console.log('error');
+                    },
+                    complete: function () {
+                        this.loading(false);
+                    },
+                });
+            };
+
+            window.setTimeout(function () {
+                $('select[data-bind^=chosen]').trigger('chosen:updated');
+            }, 300);
+        },
+        template: defaultFossilsDescriptorsTemplate,
+    },
+);

--- a/bcap/pkg/graphs/resource_models/Archaeological Site.json
+++ b/bcap/pkg/graphs/resource_models/Archaeological Site.json
@@ -2221,7 +2221,7 @@
                     "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000104"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",

--- a/bcap/pkg/graphs/resource_models/Archaeological Site.json
+++ b/bcap/pkg/graphs/resource_models/Archaeological Site.json
@@ -2224,28 +2224,6 @@
                     "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
-                    "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",
-                    "config": {
-                        "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "Publication",
-                        "placeholder": {
-                            "en": ""
-                        }
-                    },
-                    "id": "869b4236-99ef-423f-a54e-35ebdbb5a79c",
-                    "label": {
-                        "en": "Publication"
-                    },
-                    "node_id": "6b0b6935-eb55-4838-8142-3ec77f1ed5ed",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
-                },
-                {
                     "card_id": "034d1e3a-13f2-11f0-9ff8-0242ac170007",
                     "config": {
                         "dateFormat": "YYYY-MM-DD",
@@ -4174,16 +4152,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "rangenode_id": "5513b739-04f5-4c98-9e6f-def560ff3555",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "edgeid": "af10f5cf-e590-47f4-8231-ae3ca186253f",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "name": null,
-                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
-                    "rangenode_id": "6b0b6935-eb55-4838-8142-3ec77f1ed5ed",
                     "source_identifier_id": null
                 },
                 {
@@ -6441,42 +6409,6 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "publication",
-                    "config": {
-                        "graphs": [
-                            {
-                                "graphid": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
-                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
-                                "name": "Publication",
-                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
-                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
-                                "useOntologyRelationship": false
-                            }
-                        ],
-                        "searchDsl": "",
-                        "searchString": ""
-                    },
-                    "datatype": "resource-instance-list",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "REFERENCE",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Publication",
-                    "nodegroup_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "nodeid": "6b0b6935-eb55-4838-8142-3ec77f1ed5ed",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E33_Linguistic_Object",
-                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
                     "alias": "biogeography_type",
                     "config": {
                         "controlledList": "9947b6d4-e7e8-5d32-a8cf-b978fa27f31d",
@@ -7123,12 +7055,23 @@
                 {
                     "alias": "publication_reference",
                     "config": {
-                        "en": ""
+                        "graphs": [
+                            {
+                                "graphid": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "Publication",
+                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
                     },
-                    "datatype": "semantic",
+                    "datatype": "resource-instance-list",
                     "description": "{\"en\": \"\"}",
-                    "exportable": false,
-                    "fieldname": null,
+                    "exportable": true,
+                    "fieldname": "PUBREF",
                     "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
                     "hascustomalias": false,
                     "is_collector": true,
@@ -8073,9 +8016,9 @@
             "publication": {
                 "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
                 "most_recent_edit_id": null,
-                "notes": "Replace individual references fields with Publication Instances",
-                "publicationid": "6f36e137-66d3-4c07-aaf6-c27bd1bfb76f",
-                "published_time": "2026-05-13T16:57:56.110"
+                "notes": "Pull publication reference up a level",
+                "publicationid": "6d0e5236-9a94-4b4b-906e-288127f0c00d",
+                "published_time": "2026-05-13T22:35:27.816"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/bcap/pkg/graphs/resource_models/Archaeological Site.json
+++ b/bcap/pkg/graphs/resource_models/Archaeological Site.json
@@ -1837,26 +1837,6 @@
                     "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
-                    "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",
-                    "config": {
-                        "acceptedFiles": "",
-                        "defaultValue": [],
-                        "label": "Reference File",
-                        "maxFilesize": "1024",
-                        "rerender": true,
-                        "uneditable": false
-                    },
-                    "id": "5399a358-5ad2-4559-b5a5-c821480908c2",
-                    "label": {
-                        "en": "Reference File"
-                    },
-                    "node_id": "bb15839e-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 6,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000019"
-                },
-                {
                     "card_id": "b182262e-13ef-11f0-8695-0242ac170007",
                     "config": {
                         "defaultValue": {
@@ -2620,133 +2600,6 @@
                     },
                     "node_id": "dc827931-05ed-43e4-8da6-e99c0d02dae7",
                     "sortorder": 0,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
-                },
-                {
-                    "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",
-                    "config": {
-                        "defaultValue": {
-                            "en": {
-                                "direction": "ltr",
-                                "value": ""
-                            }
-                        },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "Reference Remarks",
-                        "maxLength": "500",
-                        "placeholder": {
-                            "en": "Enter text"
-                        },
-                        "uneditable": false,
-                        "width": "100%"
-                    },
-                    "id": "bb15843e-01d8-11f0-850c-0242ac170007",
-                    "label": {
-                        "en": "Reference Remarks"
-                    },
-                    "node_id": "bb15818c-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 5,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000005"
-                },
-                {
-                    "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",
-                    "config": {
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "Reference Type",
-                        "placeholder": {
-                            "en": "Select an option"
-                        },
-                        "uneditable": false
-                    },
-                    "id": "bb1584f2-01d8-11f0-850c-0242ac170007",
-                    "label": {
-                        "en": "Reference Type"
-                    },
-                    "node_id": "bb157f66-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 1,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
-                },
-                {
-                    "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",
-                    "config": {
-                        "dateFormat": "YYYY",
-                        "defaultValue": "",
-                        "label": "Reference Year",
-                        "maxDate": false,
-                        "minDate": false,
-                        "placeholder": "Enter date",
-                        "uneditable": false,
-                        "viewMode": "days"
-                    },
-                    "id": "bb158574-01d8-11f0-850c-0242ac170007",
-                    "label": {
-                        "en": "Reference Year"
-                    },
-                    "node_id": "bb15809c-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 3,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                },
-                {
-                    "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",
-                    "config": {
-                        "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "Reference Author(s)",
-                        "placeholder": {
-                            "en": "Select a person"
-                        },
-                        "uneditable": false
-                    },
-                    "id": "bb1585ec-01d8-11f0-850c-0242ac170007",
-                    "label": {
-                        "en": "Reference Author(s)"
-                    },
-                    "node_id": "bb15829a-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 4,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
-                },
-                {
-                    "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",
-                    "config": {
-                        "defaultValue": {
-                            "en": {
-                                "direction": "ltr",
-                                "value": ""
-                            }
-                        },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "Reference Title",
-                        "maxLength": "500",
-                        "placeholder": {
-                            "en": "Enter text"
-                        },
-                        "uneditable": false,
-                        "width": "100%"
-                    },
-                    "id": "bb158664-01d8-11f0-850c-0242ac170007",
-                    "label": {
-                        "en": "Reference Title"
-                    },
-                    "node_id": "bb157e3a-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4421,66 +4274,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "rangenode_id": "7e15332c-1c54-11f0-b5bf-0242ac170007",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "edgeid": "bb15ab76-01d8-11f0-850c-0242ac170007",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "rangenode_id": "bb157f66-01d8-11f0-850c-0242ac170007",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "edgeid": "bb15acc0-01d8-11f0-850c-0242ac170007",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "name": null,
-                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
-                    "rangenode_id": "bb157e3a-01d8-11f0-850c-0242ac170007",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "edgeid": "bb15adc4-01d8-11f0-850c-0242ac170007",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P92i_was_brought_into_existence_by",
-                    "rangenode_id": "bb15809c-01d8-11f0-850c-0242ac170007",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "edgeid": "bb15aebe-01d8-11f0-850c-0242ac170007",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of",
-                    "rangenode_id": "bb15818c-01d8-11f0-850c-0242ac170007",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "edgeid": "bb15afc2-01d8-11f0-850c-0242ac170007",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "name": null,
-                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L33_has_maker",
-                    "rangenode_id": "bb15829a-01d8-11f0-850c-0242ac170007",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "edgeid": "bb15b0bc-01d8-11f0-850c-0242ac170007",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "name": null,
-                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
-                    "rangenode_id": "bb15839e-01d8-11f0-850c-0242ac170007",
                     "source_identifier_id": null
                 },
                 {
@@ -6653,7 +6446,11 @@
                         "graphs": [
                             {
                                 "graphid": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
-                                "name": "Publication"
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "Publication",
+                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
                             }
                         ],
                         "searchDsl": "",
@@ -6661,8 +6458,8 @@
                     },
                     "datatype": "resource-instance-list",
                     "description": null,
-                    "exportable": false,
-                    "fieldname": null,
+                    "exportable": true,
+                    "fieldname": "REFERENCE",
                     "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
                     "hascustomalias": false,
                     "is_collector": false,
@@ -7344,162 +7141,6 @@
                     "nodeid": "bb157a2a-01d8-11f0-850c-0242ac170007",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E33_Linguistic_Object",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "reference_title",
-                    "config": {
-                        "en": ""
-                    },
-                    "datatype": "string",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "REF_TITLE",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": true,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference Title",
-                    "nodegroup_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "nodeid": "bb157e3a-01d8-11f0-850c-0242ac170007",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E41_Appellation",
-                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "reference_type",
-                    "config": {
-                        "controlledList": "74e02e4f-8587-5cfa-93b4-d81539f023dd",
-                        "multiValue": false
-                    },
-                    "datatype": "reference",
-                    "description": "Need to fix Concept name and values",
-                    "exportable": true,
-                    "fieldname": "REF_TYPE",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": true,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference Type",
-                    "nodegroup_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "nodeid": "bb157f66-01d8-11f0-850c-0242ac170007",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "reference_year",
-                    "config": {
-                        "dateFormat": "YYYY"
-                    },
-                    "datatype": "date",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "REF_YEAR",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference Year",
-                    "nodegroup_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "nodeid": "bb15809c-01d8-11f0-850c-0242ac170007",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E63_Beginning_of_Existence",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P92i_was_brought_into_existence_by",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "reference_remarks",
-                    "config": {
-                        "en": ""
-                    },
-                    "datatype": "string",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "REF_REMARK",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference Remarks",
-                    "nodegroup_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "nodeid": "bb15818c-01d8-11f0-850c-0242ac170007",
-                    "ontologyclass": "http://www.ics.forth.gr/isl/CRMdig/D29_Annotation_Object",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "reference_authors",
-                    "config": {
-                        "graphs": [],
-                        "searchDsl": "",
-                        "searchString": ""
-                    },
-                    "datatype": "resource-instance-list",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "REF_AUTHOR",
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference Authors",
-                    "nodegroup_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "nodeid": "bb15829a-01d8-11f0-850c-0242ac170007",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E39_Actor",
-                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L33_has_maker",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "reference_file",
-                    "config": {
-                        "activateMax": false,
-                        "imagesOnly": false,
-                        "maxFileSize": null,
-                        "maxFiles": 1
-                    },
-                    "datatype": "file-list",
-                    "description": null,
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference File",
-                    "nodegroup_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
-                    "nodeid": "bb15839e-01d8-11f0-850c-0242ac170007",
-                    "ontologyclass": "http://www.ics.forth.gr/isl/CRMdig/D13_Digital_Information_Carrier",
-                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
@@ -8432,9 +8073,9 @@
             "publication": {
                 "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
                 "most_recent_edit_id": null,
-                "notes": "Add publication resource instance list",
-                "publicationid": "8942b194-6fee-4f68-aada-e1a436d888ba",
-                "published_time": "2026-05-08T03:00:57.983"
+                "notes": "Replace individual references fields with Publication Instances",
+                "publicationid": "6f36e137-66d3-4c07-aaf6-c27bd1bfb76f",
+                "published_time": "2026-05-13T16:57:56.110"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/bcap/pkg/graphs/resource_models/Archaeological Site.json
+++ b/bcap/pkg/graphs/resource_models/Archaeological Site.json
@@ -951,7 +951,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Description",
                         "maxLength": null,
                         "placeholder": {
@@ -974,7 +976,9 @@
                     "card_id": "034d20f6-13f2-11f0-9ff8-0242ac170007",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Act/Section",
                         "placeholder": {
                             "en": "Select an option"
@@ -995,7 +999,9 @@
                     "card_id": "034d20f6-13f2-11f0-9ff8-0242ac170007",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Government",
                         "placeholder": {
                             "en": "Select an option"
@@ -1021,7 +1027,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Biogeography Description",
                         "maxLength": "125",
                         "placeholder": {
@@ -1049,7 +1057,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "General Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -1077,7 +1087,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Street Number",
                         "maxLength": "50",
                         "placeholder": {
@@ -1105,7 +1117,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Ancestral Remains Remarks (Restricted)",
                         "maxLength": "125",
                         "placeholder": {
@@ -1128,7 +1142,9 @@
                     "card_id": "14179b58-64ad-11f0-a4ef-6e5bb479055b",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Entered By",
                         "placeholder": {
                             "en": "Select a person"
@@ -1198,7 +1214,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Inventory Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -1226,7 +1244,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "City",
                         "maxLength": "80",
                         "placeholder": {
@@ -1254,7 +1274,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Street Name",
                         "maxLength": "80",
                         "placeholder": {
@@ -1282,7 +1304,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Postal Code",
                         "maxLength": "7",
                         "placeholder": {
@@ -1310,7 +1334,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Legal Description",
                         "maxLength": "2000",
                         "placeholder": {
@@ -1360,7 +1386,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "NROS File #",
                         "maxLength": "125",
                         "placeholder": {
@@ -1405,7 +1433,9 @@
                     "card_id": "b0ed3390-61a4-11f0-9674-3a7a4e6803c5",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Entered By",
                         "placeholder": {
                             "en": ""
@@ -1431,7 +1461,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Document Description",
                         "maxLength": "250",
                         "placeholder": {
@@ -1473,7 +1505,9 @@
                 {
                     "card_id": "2ad1641e-50ad-11f0-a6c8-0242ac170006",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Document Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -1499,7 +1533,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Tenure Remarks",
                         "maxLength": "125",
                         "placeholder": {
@@ -1527,7 +1563,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Tenure Type",
                         "maxLength": null,
                         "placeholder": {
@@ -1549,7 +1587,9 @@
                 {
                     "card_id": "f80f0aac-1977-11f0-8713-0242ac170008",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Registration Status",
                         "placeholder": {
                             "en": "Select an option"
@@ -1569,7 +1609,9 @@
                 {
                     "card_id": "67ab15bd-7377-44c4-a9e2-0ff632b14bd9",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Biogeography Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -1595,7 +1637,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "PID",
                         "maxLength": "9",
                         "placeholder": {
@@ -1637,7 +1681,9 @@
                 {
                     "card_id": "068500bc-0d07-11ed-8804-5254008afee6",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "BCAP Submission Status",
                         "placeholder": {
                             "en": "Select an option"
@@ -1683,7 +1729,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "HCA Contraventions",
                         "maxLength": null,
                         "placeholder": {
@@ -1707,7 +1755,11 @@
                     "config": {
                         "defaultValue": "",
                         "format": "",
-                        "i18n_properties": ["placeholder", "prefix", "suffix"],
+                        "i18n_properties": [
+                            "placeholder",
+                            "prefix",
+                            "suffix"
+                        ],
                         "label": "Upper (m asl)",
                         "max": "",
                         "min": "",
@@ -1765,7 +1817,9 @@
                 {
                     "card_id": "a9ce5a20-d085-4fa2-9f5b-2b812223b3d1",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "External URL Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -1797,7 +1851,7 @@
                         "en": "Reference File"
                     },
                     "node_id": "bb15839e-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 5,
+                    "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000019"
@@ -1811,7 +1865,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Site Boundary Description",
                         "maxLength": null,
                         "placeholder": {
@@ -1833,7 +1889,9 @@
                 {
                     "card_id": "034d20f6-13f2-11f0-9ff8-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Protection Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -1908,7 +1966,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Address and Legal Description Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -1931,7 +1991,9 @@
                     "card_id": "1b622c8c-0d0f-11ed-98c2-5254008afee6",
                     "config": {
                         "defaultValue": "",
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "PID",
                         "maxLength": "9",
                         "placeholder": {
@@ -1959,7 +2021,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Address",
                         "maxLength": "250",
                         "placeholder": {
@@ -1987,7 +2051,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Alert Subject",
                         "maxLength": "125",
                         "placeholder": {
@@ -2015,7 +2081,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Biogeography Name",
                         "maxLength": "125",
                         "placeholder": {
@@ -2065,7 +2133,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Typology Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -2108,7 +2178,9 @@
                     "card_id": "80c8052e-c6b1-48f4-a385-39c312b99fd3",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Entered By",
                         "placeholder": {
                             "en": "Select a person"
@@ -2151,7 +2223,9 @@
                     "card_id": "034d1e3a-13f2-11f0-9ff8-0242ac170007",
                     "config": {
                         "controlledList": "b9838a3b-731d-5c4b-b6c8-23ed827dbb7e",
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Register Type(s)",
                         "multiValue": true,
                         "placeholder": {
@@ -2168,6 +2242,28 @@
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000104"
+                },
+                {
+                    "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",
+                    "config": {
+                        "defaultResourceInstance": [],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Publication",
+                        "placeholder": {
+                            "en": ""
+                        }
+                    },
+                    "id": "869b4236-99ef-423f-a54e-35ebdbb5a79c",
+                    "label": {
+                        "en": "Publication"
+                    },
+                    "node_id": "6b0b6935-eb55-4838-8142-3ec77f1ed5ed",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
                 {
                     "card_id": "034d1e3a-13f2-11f0-9ff8-0242ac170007",
@@ -2200,7 +2296,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Parcel Owner Type(s)",
                         "maxLength": null,
                         "placeholder": {
@@ -2228,7 +2326,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Inventory Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -2256,7 +2356,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Alert Details",
                         "maxLength": null,
                         "placeholder": {
@@ -2300,7 +2402,9 @@
                 {
                     "card_id": "05baee08-61a5-11f0-9674-3a7a4e6803c5",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "General Remark Source",
                         "placeholder": {
                             "en": "Select an option"
@@ -2326,7 +2430,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Tenure Description",
                         "maxLength": null,
                         "placeholder": {
@@ -2354,7 +2460,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Restricted Information",
                         "maxLength": null,
                         "placeholder": {
@@ -2382,7 +2490,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Accuracy Remarks",
                         "maxLength": "500",
                         "placeholder": {
@@ -2463,7 +2573,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Source Notes",
                         "maxLength": null,
                         "placeholder": {
@@ -2491,7 +2603,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Keyword(s)",
                         "maxLength": "500",
                         "placeholder": {
@@ -2519,7 +2633,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Reference Remarks",
                         "maxLength": "500",
                         "placeholder": {
@@ -2533,7 +2649,7 @@
                         "en": "Reference Remarks"
                     },
                     "node_id": "bb15818c-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 4,
+                    "sortorder": 5,
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000005"
@@ -2541,7 +2657,9 @@
                 {
                     "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Reference Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -2553,7 +2671,7 @@
                         "en": "Reference Type"
                     },
                     "node_id": "bb157f66-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 0,
+                    "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
@@ -2575,7 +2693,7 @@
                         "en": "Reference Year"
                     },
                     "node_id": "bb15809c-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 2,
+                    "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000004"
@@ -2584,7 +2702,9 @@
                     "card_id": "bb157c5a-01d8-11f0-850c-0242ac170007",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Reference Author(s)",
                         "placeholder": {
                             "en": "Select a person"
@@ -2596,7 +2716,7 @@
                         "en": "Reference Author(s)"
                     },
                     "node_id": "bb15829a-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 3,
+                    "sortorder": 4,
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
@@ -2610,7 +2730,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Reference Title",
                         "maxLength": "500",
                         "placeholder": {
@@ -2624,7 +2746,7 @@
                         "en": "Reference Title"
                     },
                     "node_id": "bb157e3a-01d8-11f0-850c-0242ac170007",
-                    "sortorder": 1,
+                    "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -2638,7 +2760,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Location Description",
                         "maxLength": null,
                         "placeholder": {
@@ -2666,7 +2790,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Convictions",
                         "maxLength": null,
                         "placeholder": {
@@ -2694,7 +2820,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Copyright",
                         "maxLength": "80",
                         "placeholder": {
@@ -2716,7 +2844,9 @@
                 {
                     "card_id": "c816292c-01d8-11f0-850c-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Image Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -2781,7 +2911,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Image Caption",
                         "maxLength": null,
                         "placeholder": {
@@ -2803,7 +2935,9 @@
                 {
                     "card_id": "c816292c-01d8-11f0-850c-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Image View",
                         "placeholder": {
                             "en": "Select an option"
@@ -2829,7 +2963,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Image Photographer",
                         "maxLength": "80",
                         "placeholder": {
@@ -2857,7 +2993,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Image Feature(s)",
                         "maxLength": "250",
                         "placeholder": {
@@ -2900,7 +3038,9 @@
                     "card_id": "1b622c8c-0d0f-11ed-98c2-5254008afee6",
                     "config": {
                         "defaultValue": "",
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "PIN",
                         "maxLength": "10",
                         "placeholder": {
@@ -2923,7 +3063,9 @@
                     "card_id": "034d20f6-13f2-11f0-9ff8-0242ac170007",
                     "config": {
                         "defaultValue": "",
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Reference #",
                         "maxLength": "125",
                         "placeholder": {
@@ -2951,7 +3093,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Site Name Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -2979,7 +3123,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Site Name",
                         "maxLength": "250",
                         "placeholder": {
@@ -3001,7 +3147,9 @@
                 {
                     "card_id": "d60b1e34-35f4-11f0-afbc-0242ac170008",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Site Name Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -3022,7 +3170,9 @@
                     "card_id": "d60b1e34-35f4-11f0-afbc-0242ac170008",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Assigned or Reported By",
                         "placeholder": {
                             "en": "Select a person"
@@ -3065,7 +3215,9 @@
                     "card_id": "034d1e3a-13f2-11f0-9ff8-0242ac170007",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Parent Site",
                         "placeholder": {
                             "en": "Select parent site (if applicable)"
@@ -3085,7 +3237,9 @@
                 {
                     "card_id": "14be7a8e-c87a-4b40-815a-f872d77b0c10",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Typology",
                         "placeholder": {
                             "en": "Select an option"
@@ -3105,7 +3259,9 @@
                 {
                     "card_id": "b182262e-13ef-11f0-8695-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Edit Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -3131,7 +3287,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Restricted Remarks (Branch Access Only)",
                         "maxLength": null,
                         "placeholder": {
@@ -3159,7 +3317,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "General Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -3201,7 +3361,9 @@
                 {
                     "card_id": "034d20f6-13f2-11f0-9ff8-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Legal Instrument",
                         "placeholder": {
                             "en": "Select an option"
@@ -3222,7 +3384,9 @@
                     "card_id": "80c8052e-c6b1-48f4-a385-39c312b99fd3",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Alert Branch Contact",
                         "placeholder": {
                             "en": "Select a person"
@@ -3248,7 +3412,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Elevation Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -3272,7 +3438,11 @@
                     "config": {
                         "defaultValue": "",
                         "format": "",
-                        "i18n_properties": ["placeholder", "prefix", "suffix"],
+                        "i18n_properties": [
+                            "placeholder",
+                            "prefix",
+                            "suffix"
+                        ],
                         "label": "Lower (m asl)",
                         "max": "",
                         "min": "",
@@ -3326,7 +3496,9 @@
                     "card_id": "f80f0aac-1977-11f0-8713-0242ac170008",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Decision Maker",
                         "placeholder": {
                             "en": "Select a person"
@@ -3346,7 +3518,9 @@
                 {
                     "card_id": "f80f0aac-1977-11f0-8713-0242ac170008",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Decision/Criteria",
                         "placeholder": {
                             "en": "Select an option"
@@ -3367,7 +3541,9 @@
                     "card_id": "f80f0aac-1977-11f0-8713-0242ac170008",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Recommended By",
                         "placeholder": {
                             "en": "Select a person"
@@ -3415,7 +3591,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Decision Rationale",
                         "maxLength": null,
                         "placeholder": {
@@ -4143,6 +4321,16 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "rangenode_id": "5513b739-04f5-4c98-9e6f-def560ff3555",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
+                    "edgeid": "af10f5cf-e590-47f4-8231-ae3ca186253f",
+                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
+                    "name": null,
+                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
+                    "rangenode_id": "6b0b6935-eb55-4838-8142-3ec77f1ed5ed",
                     "source_identifier_id": null
                 },
                 {
@@ -6460,6 +6648,38 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "publication",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                                "name": "Publication"
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Publication",
+                    "nodegroup_id": "bb157a2a-01d8-11f0-850c-0242ac170007",
+                    "nodeid": "6b0b6935-eb55-4838-8142-3ec77f1ed5ed",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E33_Linguistic_Object",
+                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "biogeography_type",
                     "config": {
                         "controlledList": "9947b6d4-e7e8-5d32-a8cf-b978fa27f31d",
@@ -7645,7 +7865,10 @@
                         "falseLabel": {
                             "en": "Additional Image"
                         },
-                        "i18n_properties": ["trueLabel", "falseLabel"],
+                        "i18n_properties": [
+                            "trueLabel",
+                            "falseLabel"
+                        ],
                         "trueLabel": {
                             "en": "Primary Image"
                         }
@@ -7893,7 +8116,10 @@
                         "falseLabel": {
                             "en": "Unrestricted"
                         },
-                        "i18n_properties": ["trueLabel", "falseLabel"],
+                        "i18n_properties": [
+                            "trueLabel",
+                            "falseLabel"
+                        ],
                         "trueLabel": {
                             "en": "Restricted"
                         }
@@ -8206,9 +8432,9 @@
             "publication": {
                 "graph_id": "cef9c510-e3e6-4057-ac08-89ad926180b4",
                 "most_recent_edit_id": null,
-                "notes": "Make Arch Site geometries exportable",
-                "publicationid": "f718a53f-f99a-44af-8ed7-a54790b102c3",
-                "published_time": "2026-05-04T01:22:11.374"
+                "notes": "Add publication resource instance list",
+                "publicationid": "8942b194-6fee-4f68-aada-e1a436d888ba",
+                "published_time": "2026-05-08T03:00:57.983"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],
@@ -8308,7 +8534,7 @@
     ],
     "metadata": {
         "db": "PostgreSQL 16.3 (Debian 16.3-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
-        "git hash": "fatal: not a git repository (or any of the parent directories): .git",
+        "git hash": "d5a4f8fb2c 2026-04-22 06:33:18 -0700",
         "os": "Linux",
         "os version": "6.12.76-linuxkit"
     }

--- a/bcap/pkg/graphs/resource_models/Permit Application.json
+++ b/bcap/pkg/graphs/resource_models/Permit Application.json
@@ -6538,13 +6538,13 @@
                     "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
                 },
                 {
-                    "alias": "application_requirement",
+                    "alias": "process_requirement",
                     "config": {
                         "graphs": [
                             {
                                 "graphid": "0e74b1fa-1da4-4f17-9e65-dd79fbc96313",
                                 "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
-                                "name": "Permit Requirement",
+                                "name": "Process Requirement",
                                 "relationshipCollection": "00000000-0000-0000-0000-000000000005",
                                 "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
                                 "useOntologyRelationship": false
@@ -6564,7 +6564,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Application Requirement",
+                    "name": "Process Requirement",
                     "nodegroup_id": "c0b5fc20-bab5-4240-87aa-dcd0c96dfa58",
                     "nodeid": "c0b5fc20-bab5-4240-87aa-dcd0c96dfa58",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",
@@ -7490,9 +7490,9 @@
             "publication": {
                 "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
                 "most_recent_edit_id": null,
-                "notes": "Removed hyphen from node name",
-                "publicationid": "85b33d48-bc96-48da-9a77-821d72a2022d",
-                "published_time": "2026-05-13T16:26:13.910"
+                "notes": "Change Application Requirement to Process Requirement",
+                "publicationid": "e5912248-587b-4132-8062-8c8f50e08ec0",
+                "published_time": "2026-05-13T21:40:56.600"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/bcap/pkg/graphs/resource_models/Permit Application.json
+++ b/bcap/pkg/graphs/resource_models/Permit Application.json
@@ -610,9 +610,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Applicant Name",
                         "maxLength": null,
                         "placeholder": {
@@ -656,9 +654,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Ancestral Remains Approach Methods",
                         "maxLength": null,
                         "placeholder": {
@@ -702,9 +698,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Details of Collected Materials",
                         "maxLength": null,
                         "placeholder": {
@@ -726,9 +720,7 @@
                 {
                     "card_id": "640d8471-4f3f-476e-a0ce-70a3aff1c483",
                     "config": {
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Industrial Sector",
                         "placeholder": {
                             "en": "Select an option"
@@ -753,9 +745,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Data Analysis Methods",
                         "maxLength": null,
                         "placeholder": {
@@ -815,9 +805,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Mitigation Measures",
                         "maxLength": null,
                         "placeholder": {
@@ -845,9 +833,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "HIP Study Details",
                         "maxLength": null,
                         "placeholder": {
@@ -907,9 +893,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Scope of Work",
                         "maxLength": null,
                         "placeholder": {
@@ -937,9 +921,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "HIP Objectives",
                         "maxLength": null,
                         "placeholder": {
@@ -999,9 +981,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Collection Approach Details",
                         "maxLength": null,
                         "placeholder": {
@@ -1024,9 +1004,7 @@
                     "card_id": "4f3dd197-69e7-4c37-92b3-8d647a3b71eb",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "placeholder": {
                             "en": ""
                         }
@@ -1050,9 +1028,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Alternate Rock Art Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -1075,9 +1051,7 @@
                     "card_id": "c02b3059-dd00-4bb1-b6ba-17273c88095e",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Overseeing Archaeologist",
                         "placeholder": {
                             "en": ""
@@ -1102,9 +1076,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Ancestral Remains Approach Additional Comments",
                         "maxLength": null,
                         "placeholder": {
@@ -1132,9 +1104,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Additional Collection and Sampling Details",
                         "maxLength": null,
                         "placeholder": {
@@ -1162,9 +1132,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Subsurface Testing Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -1208,9 +1176,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Alternate Wet Sites Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -1233,9 +1199,7 @@
                     "card_id": "918189f9-4f66-49f5-a93e-031170d17a76",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Responsible External Archaeologist",
                         "placeholder": {
                             "en": ""
@@ -1255,9 +1219,7 @@
                     "card_id": "2b134cc5-2689-466c-91d8-d0ac28720f04",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Application Requirement",
                         "placeholder": {
                             "en": ""
@@ -1282,9 +1244,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Alternate CMT Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -1312,9 +1272,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Machine Assisted Inspection Methods",
                         "maxLength": null,
                         "placeholder": {
@@ -1342,9 +1300,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Scope of Work",
                         "maxLength": null,
                         "placeholder": {
@@ -1372,9 +1328,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Project Name",
                         "maxLength": null,
                         "placeholder": {
@@ -1402,9 +1356,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Field Transport and Lab Methods",
                         "maxLength": null,
                         "placeholder": {
@@ -1496,9 +1448,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Alternate Excavation Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -1520,9 +1470,7 @@
                 {
                     "card_id": "2cecb3b6-f430-4e6a-a597-a9b70823c58d",
                     "config": {
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "MAP or HIP",
                         "placeholder": {
                             "en": "Select an option"
@@ -1547,9 +1495,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Related Assessments",
                         "maxLength": null,
                         "placeholder": {
@@ -1577,9 +1523,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Alternate Ancestral Remains Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -1602,9 +1546,7 @@
                     "card_id": "c02b3059-dd00-4bb1-b6ba-17273c88095e",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Field Directors",
                         "placeholder": {
                             "en": ""
@@ -1629,9 +1571,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Additional Recording Information",
                         "maxLength": null,
                         "placeholder": {
@@ -1654,9 +1594,7 @@
                     "card_id": "637becfb-29bf-4b72-a595-f7ce5b6dd0c5",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "MZA Requirement",
                         "placeholder": {
                             "en": ""
@@ -1714,9 +1652,7 @@
                     "card_id": "637becfb-29bf-4b72-a595-f7ce5b6dd0c5",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "MZA Requirement Ministry Asignee",
                         "placeholder": {
                             "en": ""
@@ -1757,9 +1693,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Project Description",
                         "maxLength": null,
                         "placeholder": {
@@ -1803,9 +1737,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Alternate Historical Sites Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -1833,9 +1765,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Machine Assisted Inspection Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -1910,9 +1840,7 @@
                 {
                     "card_id": "79ef3bc7-4c2d-4c30-89f7-f329b324569f",
                     "config": {
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Industrial Sector",
                         "placeholder": {
                             "en": "Select an option"
@@ -1937,9 +1865,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Other Field Methods",
                         "maxLength": null,
                         "placeholder": {
@@ -1967,9 +1893,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Assessment Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -1997,9 +1921,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Additional Repository and Curation Comments",
                         "maxLength": null,
                         "placeholder": {
@@ -2037,9 +1959,7 @@
                 {
                     "card_id": "640d8471-4f3f-476e-a0ce-70a3aff1c483",
                     "config": {
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Project Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -2080,9 +2000,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Application ID",
                         "maxLength": null,
                         "placeholder": {
@@ -2105,9 +2023,7 @@
                     "card_id": "2b134cc5-2689-466c-91d8-d0ac28720f04",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Ministry Assignee",
                         "placeholder": {
                             "en": ""
@@ -2132,9 +2048,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Collection Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -2162,9 +2076,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Permit Deliverables",
                         "maxLength": null,
                         "placeholder": {
@@ -2192,9 +2104,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Other Recording Approaches",
                         "maxLength": null,
                         "placeholder": {
@@ -2222,9 +2132,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Methods Alignment",
                         "maxLength": null,
                         "placeholder": {
@@ -2246,9 +2154,7 @@
                 {
                     "card_id": "79ef3bc7-4c2d-4c30-89f7-f329b324569f",
                     "config": {
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Project Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -2273,9 +2179,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Project Description",
                         "maxLength": null,
                         "placeholder": {
@@ -2335,9 +2239,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Collection Approach Additional Comments",
                         "maxLength": null,
                         "placeholder": {
@@ -2365,9 +2267,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Details of Collected Samples",
                         "maxLength": null,
                         "placeholder": {
@@ -2390,9 +2290,7 @@
                     "card_id": "db75a7c4-64c0-44fd-81eb-7e07adc7603d",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Affected Sites",
                         "placeholder": {
                             "en": "Select one or more sites that may be affected by this project"
@@ -2433,9 +2331,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Arch Bearing Sediment",
                         "maxLength": null,
                         "placeholder": {
@@ -2463,9 +2359,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Winter Assessment Methods",
                         "maxLength": null,
                         "placeholder": {
@@ -2488,9 +2382,7 @@
                     "card_id": "5ad6a36e-0ab6-430a-9176-20fe7d6f6b1d",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Destination Repository",
                         "placeholder": {
                             "en": ""
@@ -2563,9 +2455,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "FN File Numbers",
                         "maxLength": null,
                         "placeholder": {
@@ -2652,9 +2542,7 @@
                     "card_id": "db75a7c4-64c0-44fd-81eb-7e07adc7603d",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Relevant Arch Studies",
                         "placeholder": {
                             "en": "List one or more studies that have been completed within the proposed boundary"
@@ -2679,9 +2567,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Arch Potential Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -2709,9 +2595,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Alternate Site Flagging Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -2739,9 +2623,7 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
+                        "i18n_properties": ["placeholder"],
                         "label": "Survey Coverage Approach",
                         "maxLength": null,
                         "placeholder": {
@@ -4217,10 +4099,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -4251,10 +4130,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -4340,10 +4216,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -4397,10 +4270,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -4431,10 +4301,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -4615,10 +4482,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -4664,7 +4528,7 @@
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P7_took_place_at",
                     "sortorder": 3,
                     "source_identifier_id": null,
-                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                    "sourcebranchpublication_id": null
                 },
                 {
                     "alias": "time_of_consent",
@@ -4712,7 +4576,7 @@
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of",
                     "sortorder": 0,
                     "source_identifier_id": null,
-                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                    "sourcebranchpublication_id": null
                 },
                 {
                     "alias": "hip_objectives",
@@ -4833,7 +4697,7 @@
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "sortorder": 1,
                     "source_identifier_id": null,
-                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                    "sourcebranchpublication_id": null
                 },
                 {
                     "alias": "project_boundary",
@@ -5108,10 +4972,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -5157,7 +5018,7 @@
                     "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as",
                     "sortorder": 4,
                     "source_identifier_id": null,
-                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                    "sourcebranchpublication_id": null
                 },
                 {
                     "alias": "project_name",
@@ -5188,10 +5049,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -5222,10 +5080,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -5302,10 +5157,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -5565,10 +5417,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -5769,10 +5618,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -5803,10 +5649,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -5999,7 +5842,7 @@
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P133_is_separated_from",
                     "sortorder": 0,
                     "source_identifier_id": null,
-                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                    "sourcebranchpublication_id": null
                 },
                 {
                     "alias": "first_nation_consultation",
@@ -6076,10 +5919,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -6195,10 +6035,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -6229,10 +6066,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -6286,10 +6120,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -6320,10 +6151,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -6535,7 +6363,7 @@
                     "parentproperty": "http://www.ics.forth.gr/isl/CRMsci/O7i_is_contained_or_confined",
                     "sortorder": 0,
                     "source_identifier_id": null,
-                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                    "sourcebranchpublication_id": null
                 },
                 {
                     "alias": "process_requirement",
@@ -6579,10 +6407,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -6741,7 +6566,7 @@
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
                     "source_identifier_id": null,
-                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                    "sourcebranchpublication_id": null
                 },
                 {
                     "alias": "applicant_name",
@@ -6818,10 +6643,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -6987,7 +6809,7 @@
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "sortorder": 1,
                     "source_identifier_id": null,
-                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                    "sourcebranchpublication_id": null
                 },
                 {
                     "alias": "alternate_cmt_approach",
@@ -7018,10 +6840,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -7052,10 +6871,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -7109,10 +6925,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -7358,7 +7171,7 @@
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
                     "source_identifier_id": null,
-                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                    "sourcebranchpublication_id": null
                 },
                 {
                     "alias": "has_machine_assisted_inspection",
@@ -7366,10 +7179,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -7400,10 +7210,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -7457,10 +7264,7 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
+                        "i18n_properties": ["trueLabel", "falseLabel"],
                         "trueLabel": {
                             "en": "Yes"
                         }

--- a/bcap/pkg/graphs/resource_models/Permit Application.json
+++ b/bcap/pkg/graphs/resource_models/Permit Application.json
@@ -5,6 +5,33 @@
             "cards": [
                 {
                     "active": true,
+                    "cardid": "1b01e00a-8f59-4566-af08-34dcd7c50d72",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "name": {
+                        "en": "Investigation"
+                    },
+                    "nodegroup_id": "619791bb-b417-411d-a8cb-2fbff991217b",
+                    "sortorder": 4,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "2b134cc5-2689-466c-91d8-d0ac28720f04",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -86,6 +113,33 @@
                 },
                 {
                     "active": true,
+                    "cardid": "45dc92ce-a37b-411e-8f8d-36ebd621583c",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "name": {
+                        "en": "MZA Project Details"
+                    },
+                    "nodegroup_id": "44cb22cc-13cb-4dac-a7dd-60943f26e764",
+                    "sortorder": null,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "4f3dd197-69e7-4c37-92b3-8d647a3b71eb",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -107,7 +161,7 @@
                         "en": "Related Permit"
                     },
                     "nodegroup_id": "c9b090b8-fe7a-4aaa-abaf-fa2c79c88a32",
-                    "sortorder": 5,
+                    "sortorder": 9,
                     "source_identifier_id": null,
                     "visible": true
                 },
@@ -136,7 +190,7 @@
                         "en": "Archaeological Assessment Plan"
                     },
                     "nodegroup_id": "3b80de29-9fbe-4c1f-9283-64b73fde1ad6",
-                    "sortorder": 2,
+                    "sortorder": 7,
                     "source_identifier_id": null,
                     "visible": true
                 },
@@ -163,6 +217,33 @@
                         "en": "Section 7 Repository and Curation"
                     },
                     "nodegroup_id": "1965f30d-7596-4c7c-966a-5db92d6a4a20",
+                    "sortorder": 6,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
+                    "cardid": "637becfb-29bf-4b72-a595-f7ce5b6dd0c5",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "name": {
+                        "en": "Multi Zone Area Addition"
+                    },
+                    "nodegroup_id": "935a7a4b-cdd8-422d-bb83-0e6d0dd3ceb4",
                     "sortorder": 6,
                     "source_identifier_id": null,
                     "visible": true
@@ -223,6 +304,33 @@
                 },
                 {
                     "active": true,
+                    "cardid": "79ef3bc7-4c2d-4c30-89f7-f329b324569f",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": "{\"en\": \"\"}",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "name": {
+                        "en": "MZA Proposed Project"
+                    },
+                    "nodegroup_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "7fc79758-9d05-486f-91bb-e1ecb856f9f3",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -244,7 +352,7 @@
                         "en": "Application Admin"
                     },
                     "nodegroup_id": "b2efb04e-02f7-4daf-b4fc-83512e63fb54",
-                    "sortorder": 6,
+                    "sortorder": 10,
                     "source_identifier_id": null,
                     "visible": true
                 },
@@ -298,7 +406,7 @@
                         "en": "Legal and Consent"
                     },
                     "nodegroup_id": "750da3e3-bc8a-4cd6-8879-02294fd894a0",
-                    "sortorder": 4,
+                    "sortorder": 8,
                     "source_identifier_id": null,
                     "visible": true
                 },
@@ -349,10 +457,10 @@
                         "en": ""
                     },
                     "name": {
-                        "en": "First Nation Activities and Information"
+                        "en": "First Nation Consultation"
                     },
                     "nodegroup_id": "8f8aeb8c-f8c8-4db4-8f04-32aacc5c9033",
-                    "sortorder": 3,
+                    "sortorder": 2,
                     "source_identifier_id": null,
                     "visible": true
                 },
@@ -434,6 +542,60 @@
                     },
                     "nodegroup_id": "85a1433a-62e6-496a-857a-c2470869d928",
                     "sortorder": 4,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
+                    "cardid": "f5ce7695-4b0c-40a9-a697-4a369afbccb7",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "name": {
+                        "en": "Inspection"
+                    },
+                    "nodegroup_id": "ad2a5e1c-5995-44d0-b828-6d500060b6d9",
+                    "sortorder": 5,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
+                    "cardid": "fdec6adb-56a9-4b6c-94bb-46be05ed1256",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "name": {
+                        "en": "First Nations Consultation"
+                    },
+                    "nodegroup_id": "61197e5c-a726-41e0-a0df-d4ff215d478d",
+                    "sortorder": 3,
                     "source_identifier_id": null,
                     "visible": true
                 }
@@ -1172,6 +1334,36 @@
                     "widget_id": "10000000-0000-0000-0000-000000000001"
                 },
                 {
+                    "card_id": "79ef3bc7-4c2d-4c30-89f7-f329b324569f",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Scope of Work",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Describe the scope of work to be competed as part of the proposed project"
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "5806619a-04c7-436f-90cb-09ff8a4fa6cf",
+                    "label": {
+                        "en": "Scope of Work"
+                    },
+                    "node_id": "2a6ab2f9-ad53-477b-9aa5-4d6fa95b3e0f",
+                    "sortorder": 2,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000005"
+                },
+                {
                     "card_id": "2cecb3b6-f430-4e6a-a597-a9b70823c58d",
                     "config": {
                         "defaultValue": {
@@ -1230,6 +1422,54 @@
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
+                },
+                {
+                    "card_id": "79ef3bc7-4c2d-4c30-89f7-f329b324569f",
+                    "config": {
+                        "basemap": "British Columbia Roads",
+                        "bearing": 0,
+                        "centerX": -125.2111215300115,
+                        "centerY": 54.5952920093056,
+                        "defaultValue": "",
+                        "defaultValueType": "",
+                        "featureColor": "#FF0000",
+                        "featureLineWidth": 1,
+                        "featurePointSize": 3,
+                        "geocodePlaceholder": "Search",
+                        "geocodeProvider": "10000000-0000-0000-0000-010000000000",
+                        "geocoderVisible": true,
+                        "geometryTypes": [
+                            {
+                                "id": "Point",
+                                "text": "Point"
+                            },
+                            {
+                                "id": "Line",
+                                "text": "Line"
+                            },
+                            {
+                                "id": "Polygon",
+                                "text": "Polygon"
+                            }
+                        ],
+                        "label": "Project Boundary",
+                        "maxZoom": 20,
+                        "minZoom": 0,
+                        "overlayConfigs": [],
+                        "overlayOpacity": 0,
+                        "pitch": 0,
+                        "rerender": true,
+                        "zoom": 10
+                    },
+                    "id": "62cd2888-be55-4146-8c7b-ba7cbb467ee8",
+                    "label": {
+                        "en": "Project Boundary"
+                    },
+                    "node_id": "bf84866e-d51b-4ca8-b7f8-f6e529c6071e",
+                    "sortorder": 3,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000007"
                 },
                 {
                     "card_id": "2cecb3b6-f430-4e6a-a597-a9b70823c58d",
@@ -1411,6 +1651,28 @@
                     "widget_id": "10000000-0000-0000-0000-000000000001"
                 },
                 {
+                    "card_id": "637becfb-29bf-4b72-a595-f7ce5b6dd0c5",
+                    "config": {
+                        "defaultResourceInstance": [],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "MZA Requirement",
+                        "placeholder": {
+                            "en": ""
+                        }
+                    },
+                    "id": "72af50a3-03a5-442a-8c25-03bf36e909a8",
+                    "label": {
+                        "en": "MZA Requirement"
+                    },
+                    "node_id": "c33e5100-2a04-44a6-bb4c-be0de0433266",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
+                },
+                {
                     "card_id": "2cecb3b6-f430-4e6a-a597-a9b70823c58d",
                     "config": {
                         "acceptedFiles": "",
@@ -1447,6 +1709,28 @@
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000019"
+                },
+                {
+                    "card_id": "637becfb-29bf-4b72-a595-f7ce5b6dd0c5",
+                    "config": {
+                        "defaultResourceInstance": [],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "MZA Requirement Ministry Asignee",
+                        "placeholder": {
+                            "en": ""
+                        }
+                    },
+                    "id": "7c23b3bd-741b-4757-aef5-5d5889dcd8e5",
+                    "label": {
+                        "en": "MZA Requirement Ministry Asignee"
+                    },
+                    "node_id": "72080ee9-7795-4a55-ae03-783116b893ee",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
                 },
                 {
                     "card_id": "6bff36c2-170e-4ea2-81cd-7f458ca20bbe",
@@ -1622,6 +1906,27 @@
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000004"
+                },
+                {
+                    "card_id": "79ef3bc7-4c2d-4c30-89f7-f329b324569f",
+                    "config": {
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Industrial Sector",
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "8a821d3c-dcd5-446d-823e-eddd74cedb89",
+                    "label": {
+                        "en": "Industrial Sector"
+                    },
+                    "node_id": "f3a8c99a-d229-4a33-af0e-9d9b11d89af0",
+                    "sortorder": 3,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "52a08696-dc37-4550-b5d7-5c532239e6e9",
@@ -1934,6 +2239,57 @@
                     },
                     "node_id": "e18cde43-45fa-4c1d-9f42-3d6297ed86d1",
                     "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                },
+                {
+                    "card_id": "79ef3bc7-4c2d-4c30-89f7-f329b324569f",
+                    "config": {
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Project Type",
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "af76255f-166b-45ae-8225-adc157bd3b1f",
+                    "label": {
+                        "en": "Project Type"
+                    },
+                    "node_id": "c9d7eccf-1870-4939-a0f1-67e8a9d9c5ed",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
+                },
+                {
+                    "card_id": "79ef3bc7-4c2d-4c30-89f7-f329b324569f",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Project Description",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Enter project description"
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "b277ac3a-b763-4f31-bda1-50ad8affa729",
+                    "label": {
+                        "en": "Project Description"
+                    },
+                    "node_id": "352971ee-46bd-4fbe-b227-c824c887f7ce",
+                    "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -2441,6 +2797,16 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "c33e5100-2a04-44a6-bb4c-be0de0433266",
+                    "edgeid": "04882368-7068-4c3d-9ccb-abe5e059318f",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P11_had_participant",
+                    "rangenode_id": "72080ee9-7795-4a55-ae03-783116b893ee",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
                     "domainnode_id": "d66f941b-990e-4f12-b709-4115da2ec517",
                     "edgeid": "05b4cee9-6317-43f4-be47-e9403454b9f9",
                     "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
@@ -2517,6 +2883,16 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "rangenode_id": "eb26f9e0-a963-4695-9779-871bda2916aa",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "27570b89-ce35-4434-a7af-03066283a9d4",
+                    "edgeid": "147c9f2b-04de-4134-9a7b-975d9a99bde2",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMsci/O7i_is_contained_or_confined",
+                    "rangenode_id": "bf84866e-d51b-4ca8-b7f8-f6e529c6071e",
                     "source_identifier_id": null
                 },
                 {
@@ -2621,6 +2997,16 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "edgeid": "29258f3e-0e26-4b1a-b16b-678f9d584637",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as",
+                    "rangenode_id": "44cb22cc-13cb-4dac-a7dd-60943f26e764",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
                     "domainnode_id": "77176409-f0af-4bd4-ae2a-f704b52acc62",
                     "edgeid": "2d35fdc8-32b7-439d-a292-2fc3f6ad3079",
                     "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
@@ -2657,6 +3043,16 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P11i_participated_in",
                     "rangenode_id": "a8ec1495-38de-4bb5-b056-9bfff641f022",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "44cb22cc-13cb-4dac-a7dd-60943f26e764",
+                    "edgeid": "3444e861-840e-4e30-b27d-d571702fe0fb",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "f3a8c99a-d229-4a33-af0e-9d9b11d89af0",
                     "source_identifier_id": null
                 },
                 {
@@ -2761,12 +3157,52 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "32d22a38-3ebb-4874-8df5-7f706cc01198",
+                    "edgeid": "4ad11602-d6a8-495a-8ce4-9d7a657269bd",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P70_documents",
+                    "rangenode_id": "935a7a4b-cdd8-422d-bb83-0e6d0dd3ceb4",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "935a7a4b-cdd8-422d-bb83-0e6d0dd3ceb4",
+                    "edgeid": "53d536ed-1237-40d2-8e55-813f718068f4",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P117i_includes",
+                    "rangenode_id": "c33e5100-2a04-44a6-bb4c-be0de0433266",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "32d22a38-3ebb-4874-8df5-7f706cc01198",
+                    "edgeid": "541a389b-6fe8-4975-ba4f-2ddf42fb9226",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P19i_was_made_for",
+                    "rangenode_id": "ad2a5e1c-5995-44d0-b828-6d500060b6d9",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
                     "domainnode_id": "85a1433a-62e6-496a-857a-c2470869d928",
                     "edgeid": "545c2245-b9a8-4dd6-accd-d79441300711",
                     "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "rangenode_id": "f7e8fd81-5b01-443e-b5ab-52fdd3c5b2f5",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "edgeid": "5559d546-375a-4775-a32e-9c7cbc265a93",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of",
+                    "rangenode_id": "2a6ab2f9-ad53-477b-9aa5-4d6fa95b3e0f",
                     "source_identifier_id": null
                 },
                 {
@@ -2787,6 +3223,16 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P104i_applies_to",
                     "rangenode_id": "f3018675-a20c-4086-8a7f-6b867e4bc3d1",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "32d22a38-3ebb-4874-8df5-7f706cc01198",
+                    "edgeid": "5b17c859-c2b4-43bb-875f-e421666e8b13",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P19i_was_made_for",
+                    "rangenode_id": "619791bb-b417-411d-a8cb-2fbff991217b",
                     "source_identifier_id": null
                 },
                 {
@@ -2837,6 +3283,16 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "rangenode_id": "d6bc0afe-4229-4713-bb4e-b0754acd8d4c",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "935a7a4b-cdd8-422d-bb83-0e6d0dd3ceb4",
+                    "edgeid": "6a40a9ab-ed4b-4445-8991-64a70439e3dd",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P133_is_separated_from",
+                    "rangenode_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
                     "source_identifier_id": null
                 },
                 {
@@ -3071,12 +3527,32 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "44cb22cc-13cb-4dac-a7dd-60943f26e764",
+                    "edgeid": "a84fef62-1184-444e-ac92-5d4176cfa1d8",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "rangenode_id": "dc487490-8838-4d9e-8ce5-9aff450ffe25",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
                     "domainnode_id": "0eaafb57-b280-4a73-9f04-8fe976512dfd",
                     "edgeid": "a855761c-b2ce-4c36-815a-6a4e19e730b5",
                     "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P106_is_composed_of",
                     "rangenode_id": "8d96fcc0-4d87-49cb-9255-c1cfce1b768c",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "32d22a38-3ebb-4874-8df5-7f706cc01198",
+                    "edgeid": "adf7fccc-8de7-444a-adb7-9d73e3dc3093",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P19i_was_made_for",
+                    "rangenode_id": "61197e5c-a726-41e0-a0df-d4ff215d478d",
                     "source_identifier_id": null
                 },
                 {
@@ -3271,6 +3747,16 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "edgeid": "c9d211f1-bcb2-4349-9695-c20b37273dcc",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P7_took_place_at",
+                    "rangenode_id": "27570b89-ce35-4434-a7af-03066283a9d4",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
                     "domainnode_id": "5cd90885-d09c-40f9-8d51-90747434984e",
                     "edgeid": "ca9f011b-23d8-4328-8cb0-63c0bcc75a29",
                     "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
@@ -3361,6 +3847,16 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "edgeid": "dc341dd6-c8c2-4479-8052-434fa318d74d",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "rangenode_id": "352971ee-46bd-4fbe-b227-c824c887f7ce",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
                     "domainnode_id": "5cd90885-d09c-40f9-8d51-90747434984e",
                     "edgeid": "dd577c28-c84a-4865-ad9f-0011f2e73446",
                     "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
@@ -3447,6 +3943,16 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P106_is_composed_of",
                     "rangenode_id": "2c8b96d4-37b8-4d44-970d-ea4d24a0479d",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "edgeid": "fc4f55a9-1e13-4d90-8ace-19c69ab1ae66",
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "c9d7eccf-1870-4939-a0f1-67e8a9d9c5ed",
                     "source_identifier_id": null
                 },
                 {
@@ -3556,10 +4062,31 @@
                 },
                 {
                     "cardinality": "1",
+                    "grouping_node_id": "44cb22cc-13cb-4dac-a7dd-60943f26e764",
+                    "legacygroupid": null,
+                    "nodegroupid": "44cb22cc-13cb-4dac-a7dd-60943f26e764",
+                    "parentnodegroup_id": "8e109012-2e5f-4248-bf37-7e19851a97c2"
+                },
+                {
+                    "cardinality": "1",
                     "grouping_node_id": "5cd90885-d09c-40f9-8d51-90747434984e",
                     "legacygroupid": null,
                     "nodegroupid": "5cd90885-d09c-40f9-8d51-90747434984e",
                     "parentnodegroup_id": "3b80de29-9fbe-4c1f-9283-64b73fde1ad6"
+                },
+                {
+                    "cardinality": "n",
+                    "grouping_node_id": "61197e5c-a726-41e0-a0df-d4ff215d478d",
+                    "legacygroupid": null,
+                    "nodegroupid": "61197e5c-a726-41e0-a0df-d4ff215d478d",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "n",
+                    "grouping_node_id": "619791bb-b417-411d-a8cb-2fbff991217b",
+                    "legacygroupid": null,
+                    "nodegroupid": "619791bb-b417-411d-a8cb-2fbff991217b",
+                    "parentnodegroup_id": null
                 },
                 {
                     "cardinality": "1",
@@ -3598,9 +4125,30 @@
                 },
                 {
                     "cardinality": "1",
+                    "grouping_node_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "legacygroupid": null,
+                    "nodegroupid": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "parentnodegroup_id": "935a7a4b-cdd8-422d-bb83-0e6d0dd3ceb4"
+                },
+                {
+                    "cardinality": "1",
                     "grouping_node_id": "8f8aeb8c-f8c8-4db4-8f04-32aacc5c9033",
                     "legacygroupid": null,
                     "nodegroupid": "8f8aeb8c-f8c8-4db4-8f04-32aacc5c9033",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "n",
+                    "grouping_node_id": "935a7a4b-cdd8-422d-bb83-0e6d0dd3ceb4",
+                    "legacygroupid": null,
+                    "nodegroupid": "935a7a4b-cdd8-422d-bb83-0e6d0dd3ceb4",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "n",
+                    "grouping_node_id": "ad2a5e1c-5995-44d0-b828-6d500060b6d9",
+                    "legacygroupid": null,
+                    "nodegroupid": "ad2a5e1c-5995-44d0-b828-6d500060b6d9",
                     "parentnodegroup_id": null
                 },
                 {
@@ -3611,7 +4159,7 @@
                     "parentnodegroup_id": null
                 },
                 {
-                    "cardinality": "1",
+                    "cardinality": "n",
                     "grouping_node_id": "c0b5fc20-bab5-4240-87aa-dcd0c96dfa58",
                     "legacygroupid": null,
                     "nodegroupid": "c0b5fc20-bab5-4240-87aa-dcd0c96dfa58",
@@ -4096,6 +4644,29 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "mza_project_location",
+                    "config": {},
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "MZA Project Location",
+                    "nodegroup_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "nodeid": "27570b89-ce35-4434-a7af-03066283a9d4",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E53_Place",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P7_took_place_at",
+                    "sortorder": 3,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                },
+                {
                     "alias": "time_of_consent",
                     "config": {
                         "dateFormat": "YYYY-MM-DD HH:mm:ssZ"
@@ -4119,6 +4690,29 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "mza_scope_of_work",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "MZA Scope of Work",
+                    "nodegroup_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "nodeid": "2a6ab2f9-ad53-477b-9aa5-4d6fa95b3e0f",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E89_Propositional_Object",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
                 },
                 {
                     "alias": "hip_objectives",
@@ -4217,6 +4811,29 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "mza_project_description",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "MZA Project Description",
+                    "nodegroup_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "nodeid": "352971ee-46bd-4fbe-b227-c824c887f7ce",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E62_String",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
                 },
                 {
                     "alias": "project_boundary",
@@ -4520,6 +5137,29 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "mza_project_details",
+                    "config": {},
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "MZA Project Details",
+                    "nodegroup_id": "44cb22cc-13cb-4dac-a7dd-60943f26e764",
+                    "nodeid": "44cb22cc-13cb-4dac-a7dd-60943f26e764",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",
+                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as",
+                    "sortorder": 4,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                },
+                {
                     "alias": "project_name",
                     "config": {},
                     "datatype": "string",
@@ -4796,6 +5436,52 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "first_nations_consultation",
+                    "config": {},
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "First Nations Consultation",
+                    "nodegroup_id": "61197e5c-a726-41e0-a0df-d4ff215d478d",
+                    "nodeid": "61197e5c-a726-41e0-a0df-d4ff215d478d",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P19i_was_made_for",
+                    "sortorder": 5,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "investigation",
+                    "config": {},
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Investigation",
+                    "nodegroup_id": "619791bb-b417-411d-a8cb-2fbff991217b",
+                    "nodeid": "619791bb-b417-411d-a8cb-2fbff991217b",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P19i_was_made_for",
+                    "sortorder": 4,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "section_6_ancestral_remains",
                     "config": {},
                     "datatype": "semantic",
@@ -4954,6 +5640,38 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "mza_requirement_ministry_asignee",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "605b0bbc-8661-4cf2-b340-df743a8c5f89",
+                                "name": "Contributor"
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "MZA Requirement Ministry Asignee",
+                    "nodegroup_id": "935a7a4b-cdd8-422d-bb83-0e6d0dd3ceb4",
+                    "nodeid": "72080ee9-7795-4a55-ae03-783116b893ee",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E21_Person",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P11_had_participant",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "legal_and_consent",
                     "config": {},
                     "datatype": "semantic",
@@ -4972,7 +5690,7 @@
                     "nodeid": "750da3e3-bc8a-4cd6-8879-02294fd894a0",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E30_Right",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67_refers_to",
-                    "sortorder": 3,
+                    "sortorder": 7,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -5261,7 +5979,30 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "first_nation_activities_and_information",
+                    "alias": "proposed_project_n1",
+                    "config": {},
+                    "datatype": "semantic",
+                    "description": "{\"en\": \"\"}",
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "MZA Proposed Project",
+                    "nodegroup_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "nodeid": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P133_is_separated_from",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                },
+                {
+                    "alias": "first_nation_consultation",
                     "config": {},
                     "datatype": "semantic",
                     "description": null,
@@ -5274,12 +6015,35 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "First Nation Activities and Information",
+                    "name": "First Nation Consultation",
                     "nodegroup_id": "8f8aeb8c-f8c8-4db4-8f04-32aacc5c9033",
                     "nodeid": "8f8aeb8c-f8c8-4db4-8f04-32aacc5c9033",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67_refers_to",
-                    "sortorder": 4,
+                    "sortorder": 7,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "multi_zone_area_addition",
+                    "config": {},
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Multi Zone Area Addition",
+                    "nodegroup_id": "935a7a4b-cdd8-422d-bb83-0e6d0dd3ceb4",
+                    "nodeid": "935a7a4b-cdd8-422d-bb83-0e6d0dd3ceb4",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P70_documents",
+                    "sortorder": 6,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -5494,6 +6258,29 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "inspection",
+                    "config": {},
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Inspection",
+                    "nodegroup_id": "ad2a5e1c-5995-44d0-b828-6d500060b6d9",
+                    "nodeid": "ad2a5e1c-5995-44d0-b828-6d500060b6d9",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P19i_was_made_for",
+                    "sortorder": 3,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "grant_of_license_to_ministry",
                     "config": {
                         "falseLabel": {
@@ -5629,7 +6416,7 @@
                     "nodeid": "b2efb04e-02f7-4daf-b4fc-83512e63fb54",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P16i_was_used_for",
-                    "sortorder": 6,
+                    "sortorder": 10,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -5705,6 +6492,52 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "mza_project_boundary",
+                    "config": {
+                        "addToMap": false,
+                        "advancedStyle": "",
+                        "advancedStyling": false,
+                        "clusterDistance": 20,
+                        "clusterMaxZoom": 5,
+                        "clusterMinPoints": 3,
+                        "fillColor": "rgba(130, 130, 130, 0.5)",
+                        "haloRadius": 4,
+                        "haloWeight": 4,
+                        "layerActivated": true,
+                        "layerIcon": "",
+                        "layerLegend": "",
+                        "layerName": "",
+                        "lineColor": "rgba(130, 130, 130, 0.7)",
+                        "lineHaloColor": "rgba(200, 200, 200, 0.5)",
+                        "outlineColor": "rgba(200, 200, 200, 0.7)",
+                        "outlineWeight": 2,
+                        "pointColor": "rgba(130, 130, 130, 0.7)",
+                        "pointHaloColor": "rgba(200, 200, 200, 0.5)",
+                        "radius": 2,
+                        "simplification": 0.3,
+                        "weight": 2
+                    },
+                    "datatype": "geojson-feature-collection",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "MZA Project Boundary",
+                    "nodegroup_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "nodeid": "bf84866e-d51b-4ca8-b7f8-f6e529c6071e",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E53_Place",
+                    "parentproperty": "http://www.ics.forth.gr/isl/CRMsci/O7i_is_contained_or_confined",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                },
+                {
                     "alias": "application_requirement",
                     "config": {
                         "graphs": [
@@ -5771,6 +6604,38 @@
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "mza_requirement",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "0e74b1fa-1da4-4f17-9e65-dd79fbc96313",
+                                "name": "Process Requirement"
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "MZA Requirement",
+                    "nodegroup_id": "935a7a4b-cdd8-422d-bb83-0e6d0dd3ceb4",
+                    "nodeid": "c33e5100-2a04-44a6-bb4c-be0de0433266",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P117i_includes",
+                    "sortorder": 1,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -5848,9 +6713,35 @@
                     "nodeid": "c9b090b8-fe7a-4aaa-abaf-fa2c79c88a32",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E31_Document",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67_refers_to",
-                    "sortorder": 5,
+                    "sortorder": 9,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "mza_project_type",
+                    "config": {
+                        "controlledList": "c022f098-754c-5854-8473-737d1d3cc273",
+                        "multiValue": false
+                    },
+                    "datatype": "reference",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "MZA Project Type",
+                    "nodegroup_id": "8e109012-2e5f-4248-bf37-7e19851a97c2",
+                    "nodeid": "c9d7eccf-1870-4939-a0f1-67e8a9d9c5ed",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
                 },
                 {
                     "alias": "applicant_name",
@@ -6074,6 +6965,29 @@
                     "sortorder": 2,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "mza_alteration_details",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "MZA Alteration Details",
+                    "nodegroup_id": "44cb22cc-13cb-4dac-a7dd-60943f26e764",
+                    "nodeid": "dc487490-8838-4d9e-8ce5-9aff450ffe25",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E62_String",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
                 },
                 {
                     "alias": "alternate_cmt_approach",
@@ -6421,6 +7335,32 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "mza_industrial_sector",
+                    "config": {
+                        "controlledList": "0b4ecdf1-044d-5ef2-8b95-fa3c7365ef76",
+                        "multiValue": false
+                    },
+                    "datatype": "reference",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "MZA Industrial Sector",
+                    "nodegroup_id": "44cb22cc-13cb-4dac-a7dd-60943f26e764",
+                    "nodeid": "f3a8c99a-d229-4a33-af0e-9d9b11d89af0",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": "cff9eab9-8348-4095-8b99-938e063fa1ad"
+                },
+                {
                     "alias": "has_machine_assisted_inspection",
                     "config": {
                         "falseLabel": {
@@ -6550,9 +7490,9 @@
             "publication": {
                 "graph_id": "5c900e2b-257c-4af3-b67f-b5caf3850f71",
                 "most_recent_edit_id": null,
-                "notes": "Add priority level",
-                "publicationid": "45deb330-c2c9-4801-9ef3-0dbe49616217",
-                "published_time": "2026-05-05T22:33:38.304"
+                "notes": "Removed hyphen from node name",
+                "publicationid": "85b33d48-bc96-48da-9a77-821d72a2022d",
+                "published_time": "2026-05-13T16:26:13.910"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/bcap/pkg/graphs/resource_models/Process Requirement.json
+++ b/bcap/pkg/graphs/resource_models/Process Requirement.json
@@ -1578,7 +1578,7 @@
     ],
     "metadata": {
         "db": "PostgreSQL 16.3 (Debian 16.3-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
-        "git hash": "fatal: not a git repository (or any of the parent directories): .git",
+        "git hash": "d5a4f8fb2c 2026-04-22 06:33:18 -0700",
         "os": "Linux",
         "os version": "6.12.76-linuxkit"
     }

--- a/bcap/pkg/graphs/resource_models/Publication.json
+++ b/bcap/pkg/graphs/resource_models/Publication.json
@@ -556,6 +556,36 @@
                     "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
+                    "card_id": "66575824-fa2d-4657-8c09-62e13a1ed6e5",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Publication Remarks",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Enter text"
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "bfe8af14-7cb2-4749-a072-0720a0245095",
+                    "label": {
+                        "en": "Publication Remarks"
+                    },
+                    "node_id": "289599a4-e307-4635-959e-7e415b0e8ec4",
+                    "sortorder": 7,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                },
+                {
                     "card_id": "14566eac-86b2-4263-8a0b-613537f02478",
                     "config": {
                         "defaultResourceInstance": [],
@@ -671,6 +701,16 @@
                 "en": "This resource model defines information resources, such as images, reports, and publications. "
             },
             "edges": [
+                {
+                    "description": null,
+                    "domainnode_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "edgeid": "0a572dd6-58a7-408f-88f4-66ce558c9185",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L47_has_comment",
+                    "rangenode_id": "289599a4-e307-4635-959e-7e415b0e8ec4",
+                    "source_identifier_id": null
+                },
                 {
                     "description": null,
                     "domainnode_id": "63960b1a-bc3f-11ed-bd90-5254004d77d3",
@@ -1003,7 +1043,7 @@
                     "nodeid": "037c8f98-be00-11ed-8b5e-5254004d77d3",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E19_Physical_Object",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67_refers_to",
-                    "sortorder": 0,
+                    "sortorder": 5,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -1105,6 +1145,29 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "publication_remarks",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Publication Remarks",
+                    "nodegroup_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "nodeid": "289599a4-e307-4635-959e-7e415b0e8ec4",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E62_String",
+                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L47_has_comment",
+                    "sortorder": 6,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "page_range_end",
                     "config": {
                         "en": ""
@@ -1173,7 +1236,7 @@
                     "nodeid": "45216022-c409-11ed-81a5-5254004d77d3",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E61_Time_Primitive",
                     "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L31_has_starting_date-time",
-                    "sortorder": 6,
+                    "sortorder": 5,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -1223,7 +1286,7 @@
                     "nodeid": "63960b1a-bc3f-11ed-bd90-5254004d77d3",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E42_Identifier",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
-                    "sortorder": 4,
+                    "sortorder": 3,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -1298,7 +1361,9 @@
                 },
                 {
                     "alias": "publication_identifier_type",
-                    "config": {},
+                    "config": {
+                        "rdmCollection": null
+                    },
                     "datatype": "concept",
                     "description": null,
                     "exportable": false,
@@ -1341,7 +1406,7 @@
                     "nodeid": "83f08723-772b-456c-b693-863b0f84cb07",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "sortorder": 3,
+                    "sortorder": 2,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -1369,7 +1434,7 @@
                     "nodeid": "9f210d2d-e74a-11e6-84a6-026d961c88e6",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E84_Information_Carrier",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P128i_is_carried_by",
-                    "sortorder": 0,
+                    "sortorder": 2,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -1395,7 +1460,7 @@
                     "nodeid": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67_refers_to",
-                    "sortorder": 0,
+                    "sortorder": 3,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -1533,7 +1598,7 @@
                     "nodeid": "b5f5b1ed-e74a-11e6-84a6-026d961c88e6",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "sortorder": 0,
+                    "sortorder": 4,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -1569,7 +1634,7 @@
                     "nodeid": "c03e8f18-bc30-11ed-bf42-5254004d77d3",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E39_Actor",
                     "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L33_has_maker",
-                    "sortorder": 0,
+                    "sortorder": 1,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -1754,7 +1819,7 @@
                     "nodeid": "d4f3cb86-bc3e-11ed-9b80-5254004d77d3",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P9_consists_of",
-                    "sortorder": 5,
+                    "sortorder": 4,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -1788,9 +1853,9 @@
             "publication": {
                 "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "fc5b7786-e4d3-4dbd-b0ad-ec6bf2ce8222",
-                "published_time": "2026-05-07T03:50:27.907"
+                "notes": "Reorder remarks node",
+                "publicationid": "c56cb7c7-2de4-4d58-9cb4-d715b212c81d",
+                "published_time": "2026-05-13T16:06:11.326"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],

--- a/bcap/pkg/graphs/resource_models/Publication.json
+++ b/bcap/pkg/graphs/resource_models/Publication.json
@@ -331,12 +331,10 @@
                 {
                     "card_id": "66575824-fa2d-4657-8c09-62e13a1ed6e5",
                     "config": {
-                        "defaultValue": "",
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Publication Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -349,7 +347,7 @@
                     "sortorder": 1,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "66575824-fa2d-4657-8c09-62e13a1ed6e5",
@@ -539,12 +537,10 @@
                 {
                     "card_id": "a5f5ca84-c40c-11ed-82cd-5254004d77d3",
                     "config": {
-                        "defaultValue": "",
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "Copyright Type",
-                        "options": [],
                         "placeholder": {
                             "en": "Select an option"
                         }
@@ -557,7 +553,7 @@
                     "sortorder": 0,
                     "source_identifier_id": null,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
                 },
                 {
                     "card_id": "14566eac-86b2-4263-8a0b-613537f02478",
@@ -1302,9 +1298,7 @@
                 },
                 {
                     "alias": "publication_identifier_type",
-                    "config": {
-                        "rdmCollection": null
-                    },
+                    "config": {},
                     "datatype": "concept",
                     "description": null,
                     "exportable": false,
@@ -1328,9 +1322,10 @@
                 {
                     "alias": "publication_type",
                     "config": {
-                        "rdmCollection": "74e02e4f-8587-5cfa-93b4-d81539f023dd"
+                        "controlledList": "74e02e4f-8587-5cfa-93b4-d81539f023dd",
+                        "multiValue": false
                     },
-                    "datatype": "concept",
+                    "datatype": "reference",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -1381,9 +1376,10 @@
                 {
                     "alias": "copyright_type",
                     "config": {
-                        "rdmCollection": "0b4ecdf1-044d-5ef2-8b95-fa3c7365ef76"
+                        "controlledList": "74e02e4f-8587-5cfa-93b4-d81539f023dd",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "",
                     "exportable": false,
                     "fieldname": "",
@@ -1518,9 +1514,10 @@
                 {
                     "alias": "keyword",
                     "config": {
-                        "rdmCollection": "407889ff-d24a-473e-92c8-5cd5bfe52f80"
+                        "controlledList": "74e02e4f-8587-5cfa-93b4-d81539f023dd",
+                        "multiValue": true
                     },
-                    "datatype": "concept-list",
+                    "datatype": "reference",
                     "description": "",
                     "exportable": false,
                     "fieldname": "",

--- a/bcap/pkg/graphs/resource_models/Publication.json
+++ b/bcap/pkg/graphs/resource_models/Publication.json
@@ -1361,9 +1361,7 @@
                 },
                 {
                     "alias": "publication_identifier_type",
-                    "config": {
-                        "rdmCollection": null
-                    },
+                    "config": {},
                     "datatype": "concept",
                     "description": null,
                     "exportable": false,

--- a/bcap/pkg/graphs/resource_models/Publication.json
+++ b/bcap/pkg/graphs/resource_models/Publication.json
@@ -1,0 +1,1900 @@
+{
+    "graph": [
+        {
+            "author": " GCI",
+            "cards": [
+                {
+                    "active": true,
+                    "cardid": "14566eac-86b2-4263-8a0b-613537f02478",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "name": {
+                        "en": "Reference Link"
+                    },
+                    "nodegroup_id": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "sortorder": 6,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
+                    "cardid": "28a2d308-2ac6-44ac-86ea-02b537b88acf",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "name": {
+                        "en": "Publication Identifier"
+                    },
+                    "nodegroup_id": "63960b1a-bc3f-11ed-bd90-5254004d77d3",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
+                    "cardid": "66575824-fa2d-4657-8c09-62e13a1ed6e5",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "helpenabled": true,
+                    "helptext": {
+                        "en": "<p><strong>Publication Type</strong> -&nbsp;When you pick the Publication Type &ldquo;Volume / Publication Number&rdquo;, you can enter the volume number in the &ldquo;Title of the Work&rdquo;</p>\n\n<p><strong>Other Journal or Publication Name</strong> &ndash; if the name of the publication does not exist in Journal or Publication Name list, enter the full name here.</p>\n<strong>Publication Identifier</strong> &ndash; once you have selected a Journal of Publication Name, enter the Report Number (e.g., enter the Bulletin number if it is a GSC Bulletin), or enter the URL, or enter a DOI with character string divided into a prefix and a suffix separated by a slash (e.g., 10.000/123).<br />\n&nbsp;"
+                    },
+                    "helptitle": {
+                        "en": "Publication Help Guide"
+                    },
+                    "instructions": {
+                        "en": "Enter a description for the reference."
+                    },
+                    "name": {
+                        "en": "Publication Details"
+                    },
+                    "nodegroup_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
+                    "cardid": "77f2b830-b872-4a7a-847b-c2b31160c250",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": "Select the author(s) or corporate author"
+                    },
+                    "name": {
+                        "en": "Authors"
+                    },
+                    "nodegroup_id": "c03e8f18-bc30-11ed-bf42-5254004d77d3",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
+                    "cardid": "9f210d2f-e74a-11e6-84a6-026d961c88e6",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": "",
+                    "description": {
+                        "en": "An object or substance used to record and accumulate data"
+                    },
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": "Upload pdf(s) of the reference."
+                    },
+                    "name": {
+                        "en": "Publication File"
+                    },
+                    "nodegroup_id": "9f210d2d-e74a-11e6-84a6-026d961c88e6",
+                    "sortorder": 2,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
+                    "cardid": "a5f5ca84-c40c-11ed-82cd-5254004d77d3",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": "",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "name": {
+                        "en": "Copyright Information"
+                    },
+                    "nodegroup_id": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "sortorder": 3,
+                    "source_identifier_id": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
+                    "cardid": "b5f5b1ef-e74a-11e6-84a6-026d961c88e6",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": "",
+                    "description": {
+                        "en": "An informative word used for resource information retrieval that indicates the content of a resource.\n\nRelates to resources via P2."
+                    },
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": "Select keywords associated with the resource."
+                    },
+                    "name": {
+                        "en": "Keyword"
+                    },
+                    "nodegroup_id": "b5f5b1ed-e74a-11e6-84a6-026d961c88e6",
+                    "sortorder": 4,
+                    "source_identifier_id": null,
+                    "visible": true
+                }
+            ],
+            "cards_x_nodes_x_widgets": [
+                {
+                    "card_id": "a5f5ca84-c40c-11ed-82cd-5254004d77d3",
+                    "config": {
+                        "acceptedFiles": "",
+                        "defaultValue": [],
+                        "label": "Signed Agreement",
+                        "maxFilesize": "200",
+                        "rerender": true
+                    },
+                    "id": "06a06195-4863-4f0f-a32a-8755057dedc3",
+                    "label": {
+                        "en": "Signed Agreement"
+                    },
+                    "node_id": "a5f5d268-c40c-11ed-82cd-5254004d77d3",
+                    "sortorder": 3,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000019"
+                },
+                {
+                    "card_id": "77f2b830-b872-4a7a-847b-c2b31160c250",
+                    "config": {
+                        "defaultResourceInstance": [],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Authors",
+                        "placeholder": {
+                            "en": "Select author"
+                        }
+                    },
+                    "id": "0c188b4f-d18f-4005-9cea-bdbe6e0ea538",
+                    "label": {
+                        "en": "Authors"
+                    },
+                    "node_id": "c03e8f18-bc30-11ed-bf42-5254004d77d3",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
+                },
+                {
+                    "card_id": "66575824-fa2d-4657-8c09-62e13a1ed6e5",
+                    "config": {
+                        "dateFormat": "YYYY",
+                        "defaultValue": "",
+                        "label": "Publication or Report Year",
+                        "maxDate": false,
+                        "minDate": false,
+                        "placeholder": "Enter date",
+                        "viewMode": "days"
+                    },
+                    "id": "1328ed10-1fb4-4db2-871d-d6ebd4c4ce98",
+                    "label": {
+                        "en": "Publication or Report Year"
+                    },
+                    "node_id": "45216022-c409-11ed-81a5-5254004d77d3",
+                    "sortorder": 2,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                },
+                {
+                    "card_id": "66575824-fa2d-4657-8c09-62e13a1ed6e5",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Title of the Work",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Enter the full title of published article or book, or unpublished report or thesis"
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "13c47b16-a90a-47db-a715-4d55c0f4d180",
+                    "label": {
+                        "en": "Title of the Work"
+                    },
+                    "node_id": "1930617c-c407-11ed-8154-5254004d77d3",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                },
+                {
+                    "card_id": "14566eac-86b2-4263-8a0b-613537f02478",
+                    "config": {
+                        "defaultResourceInstance": [],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Fossil Site",
+                        "placeholder": {
+                            "en": ""
+                        }
+                    },
+                    "id": "194cd8ca-673f-4c18-b23e-fa0bf4c77d29",
+                    "label": {
+                        "en": "Fossil Site"
+                    },
+                    "node_id": "20c23f8a-be00-11ed-bdf6-5254004d77d3",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
+                },
+                {
+                    "card_id": "77f2b830-b872-4a7a-847b-c2b31160c250",
+                    "config": {
+                        "defaultValue": null,
+                        "label": "Other authors unlisted"
+                    },
+                    "id": "5dca6c9d-ab46-4688-95ca-bd162496d66a",
+                    "label": {
+                        "en": "Other authors unlisted"
+                    },
+                    "node_id": "63f108ea-bdfb-11ed-a2b1-5254004d77d3",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "0346bc9c-d235-4313-adc8-d0e210b2ef25"
+                },
+                {
+                    "card_id": "66575824-fa2d-4657-8c09-62e13a1ed6e5",
+                    "config": {
+                        "defaultValue": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Publication Type",
+                        "options": [],
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "5df689fb-d110-463c-860b-85ff8afbd329",
+                    "label": {
+                        "en": "Publication Type"
+                    },
+                    "node_id": "83f08723-772b-456c-b693-863b0f84cb07",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                },
+                {
+                    "card_id": "66575824-fa2d-4657-8c09-62e13a1ed6e5",
+                    "config": {
+                        "defaultValue": "",
+                        "format": "",
+                        "i18n_properties": [
+                            "placeholder",
+                            "prefix",
+                            "suffix"
+                        ],
+                        "label": "Page Range Start",
+                        "max": "",
+                        "min": "",
+                        "placeholder": {
+                            "en": "Enter number"
+                        },
+                        "precision": "0",
+                        "prefix": {
+                            "en": ""
+                        },
+                        "step": "",
+                        "suffix": {
+                            "en": ""
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "5e242e21-a965-4b6c-9ffb-c3816fc28254",
+                    "label": {
+                        "en": "Page Range Start"
+                    },
+                    "node_id": "d4f3cb86-bc3e-11ed-9b80-5254004d77d3",
+                    "sortorder": 5,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000008"
+                },
+                {
+                    "card_id": "a5f5ca84-c40c-11ed-82cd-5254004d77d3",
+                    "config": {
+                        "defaultValue": null,
+                        "label": "Distribution Permitted"
+                    },
+                    "id": "63f69456-f65b-430c-bbc2-7cd71e4d03ed",
+                    "label": {
+                        "en": "Distribution Permitted"
+                    },
+                    "node_id": "a5f5cc8c-c40c-11ed-82cd-5254004d77d3",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000006"
+                },
+                {
+                    "card_id": "66575824-fa2d-4657-8c09-62e13a1ed6e5",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Other Journal or Volume",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Enter text"
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "75e7a802-c844-449d-8a76-8915ba00da70",
+                    "label": {
+                        "en": "Other Journal or Volume"
+                    },
+                    "node_id": "553a3d1a-bc36-11ed-a2df-5254004d77d3",
+                    "sortorder": 4,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                },
+                {
+                    "card_id": "28a2d308-2ac6-44ac-86ea-02b537b88acf",
+                    "config": {
+                        "defaultValue": "59e073cc-89fb-4e8c-a69a-ac68923486de",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Publication Identifier Type",
+                        "options": [],
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "813efb84-3f90-41f7-9990-fe5cd01698df",
+                    "label": {
+                        "en": "Publication Identifier Type"
+                    },
+                    "node_id": "76eeb332-c410-11ed-81a5-5254004d77d3",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                },
+                {
+                    "card_id": "28a2d308-2ac6-44ac-86ea-02b537b88acf",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Publication Identifier",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Enter Report Number, URL or Digital Object Identifier"
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "86a29c4f-7516-493d-95bc-233f1a2280d3",
+                    "label": {
+                        "en": "Publication Identifier"
+                    },
+                    "node_id": "63960b1a-bc3f-11ed-bd90-5254004d77d3",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                },
+                {
+                    "card_id": "9f210d2f-e74a-11e6-84a6-026d961c88e6",
+                    "config": {
+                        "acceptedFiles": "",
+                        "defaultValue": [],
+                        "label": "Publication File",
+                        "maxFilesize": "200",
+                        "rerender": true
+                    },
+                    "id": "a41054eb-e371-4c68-bda9-8d5d3e727885",
+                    "label": {
+                        "en": "Publication File"
+                    },
+                    "node_id": "9f210d2d-e74a-11e6-84a6-026d961c88e6",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000019"
+                },
+                {
+                    "card_id": "a5f5ca84-c40c-11ed-82cd-5254004d77d3",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Agreement Text",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Enter text"
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "a413df97-9682-4067-a218-4443f75c32bb",
+                    "label": {
+                        "en": "Agreement Text"
+                    },
+                    "node_id": "a5f5d6fa-c40c-11ed-82cd-5254004d77d3",
+                    "sortorder": 2,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000005"
+                },
+                {
+                    "card_id": "a5f5ca84-c40c-11ed-82cd-5254004d77d3",
+                    "config": {
+                        "defaultValue": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Copyright Type",
+                        "options": [],
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "be6a9d5d-6d7f-4eb0-bc6e-527652ce3ce2",
+                    "label": {
+                        "en": "Copyright Type"
+                    },
+                    "node_id": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                },
+                {
+                    "card_id": "14566eac-86b2-4263-8a0b-613537f02478",
+                    "config": {
+                        "defaultResourceInstance": [],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Repository",
+                        "placeholder": {
+                            "en": ""
+                        }
+                    },
+                    "id": "d947eaec-7bc0-435d-8e99-8ad4d6211505",
+                    "label": {
+                        "en": "Repository"
+                    },
+                    "node_id": "68b9813a-be01-11ed-8b5e-5254004d77d3",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
+                },
+                {
+                    "card_id": "14566eac-86b2-4263-8a0b-613537f02478",
+                    "config": {
+                        "defaultResourceInstance": [],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Collection Events",
+                        "placeholder": {
+                            "en": ""
+                        }
+                    },
+                    "id": "dcd0b3c9-6f90-4633-a496-3b5df7e4053e",
+                    "label": {
+                        "en": "Collection Events"
+                    },
+                    "node_id": "10517634-be00-11ed-b38b-5254004d77d3",
+                    "sortorder": 2,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
+                },
+                {
+                    "card_id": "66575824-fa2d-4657-8c09-62e13a1ed6e5",
+                    "config": {
+                        "defaultValue": "",
+                        "format": "",
+                        "i18n_properties": [
+                            "placeholder",
+                            "prefix",
+                            "suffix"
+                        ],
+                        "label": "Page Range End",
+                        "max": "",
+                        "min": "",
+                        "placeholder": {
+                            "en": "Enter number"
+                        },
+                        "precision": "0",
+                        "prefix": {
+                            "en": ""
+                        },
+                        "step": "",
+                        "suffix": {
+                            "en": ""
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "e0d389ae-98c5-49e5-8816-4575be4fe4b0",
+                    "label": {
+                        "en": "Page Range End"
+                    },
+                    "node_id": "2d410f4c-bc3f-11ed-a483-5254004d77d3",
+                    "sortorder": 6,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000008"
+                },
+                {
+                    "card_id": "66575824-fa2d-4657-8c09-62e13a1ed6e5",
+                    "config": {
+                        "defaultResourceInstance": [],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Journal or Volume the Publication was published in",
+                        "placeholder": {
+                            "en": "Select Journal or Publication Name"
+                        }
+                    },
+                    "id": "ed5ea949-a03f-4a91-b193-6fbecb67ef87",
+                    "label": {
+                        "en": "Journal or Volume the Publication was published in"
+                    },
+                    "node_id": "c89a294c-bc35-11ed-9b80-5254004d77d3",
+                    "sortorder": 3,
+                    "source_identifier_id": null,
+                    "visible": true,
+                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
+                }
+            ],
+            "color": "rgba(37,168,152,1)",
+            "config": {
+                "nodes": [
+                    "9f210d2d-e74a-11e6-84a6-026d961c88e6"
+                ]
+            },
+            "deploymentdate": null,
+            "deploymentfile": null,
+            "description": {
+                "en": "This resource model defines information resources, such as images, reports, and publications. "
+            },
+            "edges": [
+                {
+                    "description": null,
+                    "domainnode_id": "63960b1a-bc3f-11ed-bd90-5254004d77d3",
+                    "edgeid": "14bd9c80-aa17-4697-aab9-cd80ec250aab",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "76eeb332-c410-11ed-81a5-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "3caf329e-b8f7-11e6-84a5-026d961c88e6",
+                    "edgeid": "1d915cfd-3528-48a3-abba-676e0f680c47",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L33_has_maker",
+                    "rangenode_id": "c03e8f18-bc30-11ed-bf42-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "edgeid": "3adfe03c-808f-463e-93ca-2d9ca21f04d7",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "rangenode_id": "63960b1a-bc3f-11ed-bd90-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "3caf329e-b8f7-11e6-84a5-026d961c88e6",
+                    "edgeid": "43f51010-c557-48bb-92b0-2b58c6350917",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P140i_was_attributed_by",
+                    "rangenode_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "d4f3cb86-bc3e-11ed-9b80-5254004d77d3",
+                    "edgeid": "46b88197-df8f-4e6c-963b-86d98e7525ab",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P9_consists_of",
+                    "rangenode_id": "2d410f4c-bc3f-11ed-a483-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "edgeid": "4d117296-bb0c-4d8e-8a04-b91c5d8d8125",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P10i_contains",
+                    "rangenode_id": "c89a294c-bc35-11ed-9b80-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "edgeid": "515c9de8-4993-45f7-ad81-2afe96fd5965",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L31_has_starting_date-time",
+                    "rangenode_id": "45216022-c409-11ed-81a5-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "edgeid": "5504bba2-d144-4b6f-a7a2-eda189d9a7a4",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
+                    "rangenode_id": "68b9813a-be01-11ed-8b5e-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "c89a294c-bc35-11ed-9b80-5254004d77d3",
+                    "edgeid": "646c9192-40f4-4149-aec9-b263de7577f1",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as",
+                    "rangenode_id": "553a3d1a-bc36-11ed-a2df-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "3caf329e-b8f7-11e6-84a5-026d961c88e6",
+                    "edgeid": "752a4df1-b1ca-4281-b19b-21ee135e0b56",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P67_refers_to",
+                    "rangenode_id": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "edgeid": "8a2c6223-4b58-4a7f-8fce-d80d1cf0a983",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P9_consists_of",
+                    "rangenode_id": "d4f3cb86-bc3e-11ed-9b80-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "3caf329e-b8f7-11e6-84a5-026d961c88e6",
+                    "edgeid": "95f427cd-bb48-4417-bfa6-c6d398332d15",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P67_refers_to",
+                    "rangenode_id": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "edgeid": "9644a892-21fd-41ae-9d23-2191b222af0f",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "83f08723-772b-456c-b693-863b0f84cb07",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "3caf329e-b8f7-11e6-84a5-026d961c88e6",
+                    "edgeid": "9f210d34-e74a-11e6-84a6-026d961c88e6",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P128i_is_carried_by",
+                    "rangenode_id": "9f210d2d-e74a-11e6-84a6-026d961c88e6",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "edgeid": "a5f5f702-c40c-11ed-82cd-5254004d77d3",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P125i_was_type_of_object_used_in",
+                    "rangenode_id": "a5f5cc8c-c40c-11ed-82cd-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "a5f5cc8c-c40c-11ed-82cd-5254004d77d3",
+                    "edgeid": "a5f5fb08-c40c-11ed-82cd-5254004d77d3",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P10_falls_within",
+                    "rangenode_id": "a5f5ce62-c40c-11ed-82cd-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "a5f5ce62-c40c-11ed-82cd-5254004d77d3",
+                    "edgeid": "a5f5fcb6-c40c-11ed-82cd-5254004d77d3",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P10_falls_within",
+                    "rangenode_id": "a5f5d268-c40c-11ed-82cd-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "a5f5ce62-c40c-11ed-82cd-5254004d77d3",
+                    "edgeid": "a5f5fe32-c40c-11ed-82cd-5254004d77d3",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P10_falls_within",
+                    "rangenode_id": "a5f5d6fa-c40c-11ed-82cd-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "3caf329e-b8f7-11e6-84a5-026d961c88e6",
+                    "edgeid": "b5f5b1f1-e74a-11e6-84a6-026d961c88e6",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "b5f5b1ed-e74a-11e6-84a6-026d961c88e6",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "edgeid": "b6ed23ad-52b2-4073-9b0e-a37b71ce35db",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "rangenode_id": "1930617c-c407-11ed-8154-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "c03e8f18-bc30-11ed-bf42-5254004d77d3",
+                    "edgeid": "c36a2af9-da3e-47f1-ae16-6d57c0fac13a",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P140i_was_attributed_by",
+                    "rangenode_id": "63f108ea-bdfb-11ed-a2b1-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "edgeid": "cbf85ea3-eff9-4c98-a2ff-7fde3239e377",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
+                    "rangenode_id": "20c23f8a-be00-11ed-bdf6-5254004d77d3",
+                    "source_identifier_id": null
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "edgeid": "e8497aaf-60ef-4423-bfde-d6ce6bca3f37",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "name": null,
+                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
+                    "rangenode_id": "10517634-be00-11ed-b38b-5254004d77d3",
+                    "source_identifier_id": null
+                }
+            ],
+            "functions_x_graphs": [
+                {
+                    "config": {
+                        "class_name": "PublicationDescriptors",
+                        "descriptor_types": {
+                            "description": {},
+                            "map_popup": {},
+                            "name": {}
+                        },
+                        "module": "bcap.functions.publication_descriptors",
+                        "triggering_nodegroups": []
+                    },
+                    "function_id": "60000000-0000-0000-0000-000000001003",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "id": "e9bae01e-5603-436b-9212-69d6d8b943c4"
+                }
+            ],
+            "graphid": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+            "group_permissions": {},
+            "has_unpublished_changes": true,
+            "iconclass": "fa fa-book",
+            "is_active": true,
+            "is_copy_immutable": false,
+            "isresource": true,
+            "jsonldcontext": null,
+            "name": {
+                "en": "Publication"
+            },
+            "nodegroups": [
+                {
+                    "cardinality": "1",
+                    "grouping_node_id": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "legacygroupid": null,
+                    "nodegroupid": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "n",
+                    "grouping_node_id": "63960b1a-bc3f-11ed-bd90-5254004d77d3",
+                    "legacygroupid": null,
+                    "nodegroupid": "63960b1a-bc3f-11ed-bd90-5254004d77d3",
+                    "parentnodegroup_id": "e9366370-bc33-11ed-bf42-5254004d77d3"
+                },
+                {
+                    "cardinality": "n",
+                    "grouping_node_id": "9f210d2d-e74a-11e6-84a6-026d961c88e6",
+                    "legacygroupid": null,
+                    "nodegroupid": "9f210d2d-e74a-11e6-84a6-026d961c88e6",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "1",
+                    "grouping_node_id": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "legacygroupid": null,
+                    "nodegroupid": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "n",
+                    "grouping_node_id": "b5f5b1ed-e74a-11e6-84a6-026d961c88e6",
+                    "legacygroupid": null,
+                    "nodegroupid": "b5f5b1ed-e74a-11e6-84a6-026d961c88e6",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "n",
+                    "grouping_node_id": "c03e8f18-bc30-11ed-bf42-5254004d77d3",
+                    "legacygroupid": null,
+                    "nodegroupid": "c03e8f18-bc30-11ed-bf42-5254004d77d3",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "1",
+                    "grouping_node_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "legacygroupid": null,
+                    "nodegroupid": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "parentnodegroup_id": null
+                }
+            ],
+            "nodes": [
+                {
+                    "alias": "reference_link",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Reference Link",
+                    "nodegroup_id": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "nodeid": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E19_Physical_Object",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67_refers_to",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "site_visits",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "Site Visit",
+                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Site Visits",
+                    "nodegroup_id": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "nodeid": "10517634-be00-11ed-b38b-5254004d77d3",
+                    "ontologyclass": "http://www.ics.forth.gr/isl/CRMsci/S2_Sample_Taking",
+                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "title",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": "title",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": true,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Title",
+                    "nodegroup_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "nodeid": "1930617c-c407-11ed-8154-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E41_Appellation",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "archaeological_sites",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "cef9c510-e3e6-4057-ac08-89ad926180b4",
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "Archaeological Site",
+                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Archaeological Sites",
+                    "nodegroup_id": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "nodeid": "20c23f8a-be00-11ed-bdf6-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E92_Spacetime_Volume",
+                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "page_range_end",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "number",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Page Range End",
+                    "nodegroup_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "nodeid": "2d410f4c-bc3f-11ed-a483-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P9_consists_of",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "bc_information_resource_model",
+                    "config": {},
+                    "datatype": "semantic",
+                    "description": "",
+                    "exportable": false,
+                    "fieldname": "",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": true,
+                    "name": "Publication",
+                    "nodegroup_id": null,
+                    "nodeid": "3caf329e-b8f7-11e6-84a5-026d961c88e6",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object",
+                    "parentproperty": "",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "year_of_publication",
+                    "config": {
+                        "dateFormat": "YYYY"
+                    },
+                    "datatype": "date",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": "pub_yr",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": true,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Year of Publication",
+                    "nodegroup_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "nodeid": "45216022-c409-11ed-81a5-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E61_Time_Primitive",
+                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L31_has_starting_date-time",
+                    "sortorder": 6,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "other_journal_or_volume_name",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "string",
+                    "description": "The the Journal or Volume is not present in the list it can be entered in this field. Values in this field should be added to the Journal or Volume Name if they are acceptable by FMO.",
+                    "exportable": true,
+                    "fieldname": "oth_name",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Other Journal or Volume Name",
+                    "nodegroup_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "nodeid": "553a3d1a-bc36-11ed-a2df-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E19_Physical_Object",
+                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_identifier",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Publication Identifier",
+                    "nodegroup_id": "63960b1a-bc3f-11ed-bd90-5254004d77d3",
+                    "nodeid": "63960b1a-bc3f-11ed-bd90-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E42_Identifier",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "sortorder": 4,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "other_authors_unlisted",
+                    "config": {
+                        "falseLabel": {
+                            "en": "Author list complete"
+                        },
+                        "i18n_properties": [
+                            "trueLabel",
+                            "falseLabel"
+                        ],
+                        "trueLabel": {
+                            "en": "Additional unlisted authors"
+                        }
+                    },
+                    "datatype": "boolean",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Other authors unlisted",
+                    "nodegroup_id": "c03e8f18-bc30-11ed-bf42-5254004d77d3",
+                    "nodeid": "63f108ea-bdfb-11ed-a2b1-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P140i_was_attributed_by",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "repositories",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "3e6a2880-14d4-11ec-9df0-5254008afee6",
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "BC Fossil Storage Location",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Repositories",
+                    "nodegroup_id": "037c8f98-be00-11ed-8b5e-5254004d77d3",
+                    "nodeid": "68b9813a-be01-11ed-8b5e-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E92_Spacetime_Volume",
+                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
+                    "sortorder": 2,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_identifier_type",
+                    "config": {
+                        "rdmCollection": null
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Publication Identifier Type",
+                    "nodegroup_id": "63960b1a-bc3f-11ed-bd90-5254004d77d3",
+                    "nodeid": "76eeb332-c410-11ed-81a5-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_type",
+                    "config": {
+                        "rdmCollection": "74e02e4f-8587-5cfa-93b4-d81539f023dd"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Publication Type",
+                    "nodegroup_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "nodeid": "83f08723-772b-456c-b693-863b0f84cb07",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 3,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "information_carrier",
+                    "config": {
+                        "activateMax": false,
+                        "imagesOnly": false,
+                        "maxFileSize": null,
+                        "maxFiles": 1
+                    },
+                    "datatype": "file-list",
+                    "description": "",
+                    "exportable": false,
+                    "fieldname": "",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Information Carrier",
+                    "nodegroup_id": "9f210d2d-e74a-11e6-84a6-026d961c88e6",
+                    "nodeid": "9f210d2d-e74a-11e6-84a6-026d961c88e6",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E84_Information_Carrier",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P128i_is_carried_by",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "copyright_type",
+                    "config": {
+                        "rdmCollection": "0b4ecdf1-044d-5ef2-8b95-fa3c7365ef76"
+                    },
+                    "datatype": "concept-list",
+                    "description": "",
+                    "exportable": false,
+                    "fieldname": "",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": true,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Copyright Type",
+                    "nodegroup_id": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "nodeid": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67_refers_to",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "distribution_permitted",
+                    "config": {
+                        "falseLabel": {
+                            "en": "No"
+                        },
+                        "i18n_properties": [
+                            "trueLabel",
+                            "falseLabel"
+                        ],
+                        "trueLabel": {
+                            "en": "Yes"
+                        }
+                    },
+                    "datatype": "boolean",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Distribution Permitted",
+                    "nodegroup_id": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "nodeid": "a5f5cc8c-c40c-11ed-82cd-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E11_Modification",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P125i_was_type_of_object_used_in",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "distribution_agreement",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Distribution Agreement",
+                    "nodegroup_id": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "nodeid": "a5f5ce62-c40c-11ed-82cd-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E10_Transfer_of_Custody",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P10_falls_within",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "signed_agreement",
+                    "config": {
+                        "activateMax": false,
+                        "imagesOnly": false,
+                        "maxFileSize": null,
+                        "maxFiles": 1
+                    },
+                    "datatype": "file-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Signed Agreement",
+                    "nodegroup_id": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "nodeid": "a5f5d268-c40c-11ed-82cd-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E10_Transfer_of_Custody",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P10_falls_within",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "agreement_text",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Agreement Text",
+                    "nodegroup_id": "a5f5c7b4-c40c-11ed-82cd-5254004d77d3",
+                    "nodeid": "a5f5d6fa-c40c-11ed-82cd-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E10_Transfer_of_Custody",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P10_falls_within",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "keyword",
+                    "config": {
+                        "rdmCollection": "407889ff-d24a-473e-92c8-5cd5bfe52f80"
+                    },
+                    "datatype": "concept-list",
+                    "description": "",
+                    "exportable": false,
+                    "fieldname": "",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Keyword",
+                    "nodegroup_id": "b5f5b1ed-e74a-11e6-84a6-026d961c88e6",
+                    "nodeid": "b5f5b1ed-e74a-11e6-84a6-026d961c88e6",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "authors",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "605b0bbc-8661-4cf2-b340-df743a8c5f89",
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "Contributor",
+                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance-list",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": "author",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": true,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Authors",
+                    "nodegroup_id": "c03e8f18-bc30-11ed-bf42-5254004d77d3",
+                    "nodeid": "c03e8f18-bc30-11ed-bf42-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E39_Actor",
+                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L33_has_maker",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "journal_or_volume_name",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "Publication",
+                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
+                            }
+                        ],
+                        "searchDsl": {
+                            "bool": {
+                                "filter": [
+                                    {
+                                        "terms": {
+                                            "graph_id": [
+                                                "82efcd14-82db-11ec-b8e6-5254008afee6",
+                                                "5b52dcac-9c1b-11ec-964d-5254008afee6",
+                                                "67574dc6-9c20-11ec-964d-5254008afee6",
+                                                "3e6a2880-14d4-11ec-9df0-5254008afee6",
+                                                "dd19a93a-0202-11ed-a511-0050568377a0",
+                                                "7f2c2082-6c51-11ed-9b7d-5254004d77d3",
+                                                "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                                                "8a209060-9c20-11ec-955e-5254008afee6",
+                                                "ff623370-fa12-11e6-b98b-6c4008b05c4c",
+                                                "3eec83c6-9dd5-11ed-a81c-5254004d77d3",
+                                                "fac1b1b4-1034-11ec-8a7a-5254008afee6",
+                                                "df3ee1ae-9c1c-11ec-964d-5254008afee6",
+                                                "d735935c-3ddb-11ed-814d-5254008afee6",
+                                                "3ffba33a-9c20-11ec-92da-5254008afee6",
+                                                "c3923080-d21e-42d7-b8f1-637b9d0ab63c",
+                                                "109a0272-d968-11ed-b8ae-5254004d77d3",
+                                                "2aa724d1-ffd3-4823-8ff1-15a385b9a407",
+                                                "605b0bbc-8661-4cf2-b340-df743a8c5f89",
+                                                "4d6c9226-10c6-11ec-9a94-5254008afee6",
+                                                "3bad9ec8-a35e-11ed-884a-5254004d77d3",
+                                                "a9617d92-28f2-427f-901f-42f1cb4214b0",
+                                                "3746ffc8-a878-11ec-ab9a-5254008afee6",
+                                                "86700278-117b-11ec-90d4-5254008afee6"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "must": [
+                                    {
+                                        "bool": {
+                                            "filter": [],
+                                            "minimum_should_match": 1,
+                                            "must": [],
+                                            "must_not": [],
+                                            "should": [
+                                                {
+                                                    "bool": {
+                                                        "filter": [],
+                                                        "must": [
+                                                            {
+                                                                "nested": {
+                                                                    "path": "tiles",
+                                                                    "query": {
+                                                                        "bool": {
+                                                                            "filter": [],
+                                                                            "must": [
+                                                                                {
+                                                                                    "match_phrase": {
+                                                                                        "tiles.data.e1dbcf2e-4b1c-40ad-93d3-ba3743b60b12": {
+                                                                                            "query": "1bae9ef6-3913-4405-b4d5-7bf7d94405ce"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ],
+                                                                            "must_not": [],
+                                                                            "should": []
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            {
+                                                                "bool": {
+                                                                    "filter": [],
+                                                                    "must": [],
+                                                                    "must_not": [],
+                                                                    "should": []
+                                                                }
+                                                            }
+                                                        ],
+                                                        "must_not": [],
+                                                        "should": []
+                                                    }
+                                                },
+                                                {
+                                                    "bool": {
+                                                        "filter": [],
+                                                        "must": [
+                                                            {
+                                                                "nested": {
+                                                                    "path": "tiles",
+                                                                    "query": {
+                                                                        "bool": {
+                                                                            "filter": [],
+                                                                            "must": [
+                                                                                {
+                                                                                    "match_phrase": {
+                                                                                        "tiles.data.e1dbcf2e-4b1c-40ad-93d3-ba3743b60b12": {
+                                                                                            "query": "5b466670-b855-4c6a-9a29-4399a8d205ec"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ],
+                                                                            "must_not": [],
+                                                                            "should": []
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            {
+                                                                "bool": {
+                                                                    "filter": [],
+                                                                    "must": [],
+                                                                    "must_not": [],
+                                                                    "should": []
+                                                                }
+                                                            }
+                                                        ],
+                                                        "must_not": [],
+                                                        "should": []
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "must_not": [],
+                                "should": []
+                            }
+                        },
+                        "searchString": "/bc-fossil-management/search?paging-filter=1&tiles=true&format=tilecsv&reportlink=false&precision=6&total=0&advanced-search=%5B%7B%22op%22%3A%22and%22%2C%221930617c-c407-11ed-8154-5254004d77d3%22%3A%7B%22op%22%3A%22~%22%2C%22lang%22%3A%22en%22%2C%22val%22%3A%22%22%7D%2C%2245216022-c409-11ed-81a5-5254004d77d3%22%3A%7B%22op%22%3A%22eq%22%2C%22val%22%3A%22%22%7D%2C%22e1dbcf2e-4b1c-40ad-93d3-ba3743b60b12%22%3A%7B%22op%22%3A%22eq%22%2C%22val%22%3A%221bae9ef6-3913-4405-b4d5-7bf7d94405ce%22%7D%2C%22c89a294c-bc35-11ed-9b80-5254004d77d3%22%3A%7B%22op%22%3A%22%22%2C%22val%22%3A%22%22%7D%2C%22553a3d1a-bc36-11ed-a2df-5254004d77d3%22%3A%7B%22op%22%3A%22~%22%2C%22lang%22%3A%22en%22%2C%22val%22%3A%22%22%7D%2C%22d4f3cb86-bc3e-11ed-9b80-5254004d77d3%22%3A%7B%22op%22%3A%22eq%22%2C%22val%22%3A%22%22%7D%2C%222d410f4c-bc3f-11ed-a483-5254004d77d3%22%3A%7B%22op%22%3A%22eq%22%2C%22val%22%3A%22%22%7D%2C%2263960b1a-bc3f-11ed-bd90-5254004d77d3%22%3A%7B%22op%22%3A%22~%22%2C%22lang%22%3A%22en%22%2C%22val%22%3A%22%22%7D%7D%2C%7B%22op%22%3A%22or%22%2C%221930617c-c407-11ed-8154-5254004d77d3%22%3A%7B%22op%22%3A%22~%22%2C%22lang%22%3A%22en%22%2C%22val%22%3A%22%22%7D%2C%2245216022-c409-11ed-81a5-5254004d77d3%22%3A%7B%22op%22%3A%22eq%22%2C%22val%22%3A%22%22%7D%2C%22e1dbcf2e-4b1c-40ad-93d3-ba3743b60b12%22%3A%7B%22op%22%3A%22eq%22%2C%22val%22%3A%225b466670-b855-4c6a-9a29-4399a8d205ec%22%7D%2C%22c89a294c-bc35-11ed-9b80-5254004d77d3%22%3A%7B%22op%22%3A%22%22%2C%22val%22%3A%22%22%7D%2C%22553a3d1a-bc36-11ed-a2df-5254004d77d3%22%3A%7B%22op%22%3A%22~%22%2C%22lang%22%3A%22en%22%2C%22val%22%3A%22%22%7D%2C%22d4f3cb86-bc3e-11ed-9b80-5254004d77d3%22%3A%7B%22op%22%3A%22eq%22%2C%22val%22%3A%22%22%7D%2C%222d410f4c-bc3f-11ed-a483-5254004d77d3%22%3A%7B%22op%22%3A%22eq%22%2C%22val%22%3A%22%22%7D%2C%2263960b1a-bc3f-11ed-bd90-5254004d77d3%22%3A%7B%22op%22%3A%22~%22%2C%22lang%22%3A%22en%22%2C%22val%22%3A%22%22%7D%7D%5D"
+                    },
+                    "datatype": "resource-instance",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": "jour_name",
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Journal or Volume Name",
+                    "nodegroup_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "nodeid": "c89a294c-bc35-11ed-9b80-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P10i_contains",
+                    "sortorder": 1,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "page_range_start",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "number",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Page Range Start",
+                    "nodegroup_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "nodeid": "d4f3cb86-bc3e-11ed-9b80-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P9_consists_of",
+                    "sortorder": 5,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_details",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "is_immutable": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Publication Details",
+                    "nodegroup_id": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "nodeid": "e9366370-bc33-11ed-bf42-5254004d77d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P140i_was_attributed_by",
+                    "sortorder": 0,
+                    "source_identifier_id": null,
+                    "sourcebranchpublication_id": null
+                }
+            ],
+            "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
+            "publication": {
+                "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                "most_recent_edit_id": null,
+                "notes": null,
+                "publicationid": "fc5b7786-e4d3-4dbd-b0ad-ec6bf2ce8222",
+                "published_time": "2026-05-07T03:50:27.907"
+            },
+            "relatable_resource_model_ids": [],
+            "resource_2_resource_constraints": [],
+            "resource_instance_lifecycle": {
+                "id": "7e3cce56-fbfb-4a4b-8e83-59b9f9e7cb75",
+                "name": {
+                    "en": "Standard"
+                },
+                "resource_instance_lifecycle_states": [
+                    {
+                        "action_label": {
+                            "en": "Revert to Draft"
+                        },
+                        "can_delete_resource_instances": true,
+                        "can_edit_resource_instances": true,
+                        "id": "9375c9a7-dad2-4f14-a5c1-d7e329fdde4f",
+                        "is_initial_state": true,
+                        "name": {
+                            "en": "Draft"
+                        },
+                        "next_resource_instance_lifecycle_states": [
+                            "f75bb034-36e3-4ab4-8167-f520cf0b4c58"
+                        ],
+                        "previous_resource_instance_lifecycle_states": [],
+                        "resource_instance_lifecycle_id": "7e3cce56-fbfb-4a4b-8e83-59b9f9e7cb75"
+                    },
+                    {
+                        "action_label": {
+                            "en": "Make Active"
+                        },
+                        "can_delete_resource_instances": false,
+                        "can_edit_resource_instances": true,
+                        "id": "f75bb034-36e3-4ab4-8167-f520cf0b4c58",
+                        "is_initial_state": false,
+                        "name": {
+                            "en": "Active"
+                        },
+                        "next_resource_instance_lifecycle_states": [
+                            "d95d9c0e-0e2c-4450-93a3-d788b91abcc8"
+                        ],
+                        "previous_resource_instance_lifecycle_states": [
+                            "9375c9a7-dad2-4f14-a5c1-d7e329fdde4f"
+                        ],
+                        "resource_instance_lifecycle_id": "7e3cce56-fbfb-4a4b-8e83-59b9f9e7cb75"
+                    },
+                    {
+                        "action_label": {
+                            "en": "Retire"
+                        },
+                        "can_delete_resource_instances": false,
+                        "can_edit_resource_instances": false,
+                        "id": "d95d9c0e-0e2c-4450-93a3-d788b91abcc8",
+                        "is_initial_state": false,
+                        "name": {
+                            "en": "Retired"
+                        },
+                        "next_resource_instance_lifecycle_states": [],
+                        "previous_resource_instance_lifecycle_states": [
+                            "f75bb034-36e3-4ab4-8167-f520cf0b4c58"
+                        ],
+                        "resource_instance_lifecycle_id": "7e3cce56-fbfb-4a4b-8e83-59b9f9e7cb75"
+                    }
+                ]
+            },
+            "root": {
+                "alias": "bc_information_resource_model",
+                "config": {},
+                "datatype": "semantic",
+                "description": "",
+                "exportable": false,
+                "fieldname": "",
+                "graph_id": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                "hascustomalias": false,
+                "is_collector": false,
+                "is_immutable": false,
+                "isrequired": false,
+                "issearchable": true,
+                "istopnode": true,
+                "name": "Publication",
+                "nodegroup_id": null,
+                "nodeid": "3caf329e-b8f7-11e6-84a5-026d961c88e6",
+                "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object",
+                "sortorder": 0,
+                "source_identifier_id": null,
+                "sourcebranchpublication_id": null
+            },
+            "slug": "publication",
+            "source_identifier_id": null,
+            "spatial_views": [],
+            "subtitle": {
+                "en": "Details of reference information related to fossil samples and sites"
+            },
+            "template_id": "50000000-0000-0000-0000-000000000001",
+            "user_permissions": {},
+            "version": ""
+        }
+    ],
+    "metadata": {
+        "db": "PostgreSQL 16.3 (Debian 16.3-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
+        "git hash": "d5a4f8fb2c 2026-04-22 06:33:18 -0700",
+        "os": "Linux",
+        "os version": "6.12.76-linuxkit"
+    }
+}

--- a/bcap/pkg/graphs/resource_models/Site Visit.json
+++ b/bcap/pkg/graphs/resource_models/Site Visit.json
@@ -685,7 +685,9 @@
                 {
                     "card_id": "15f3be27-7841-4672-9c7f-72eff82cd4de",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Image View",
                         "placeholder": {
                             "en": "Select an option"
@@ -707,7 +709,11 @@
                     "config": {
                         "defaultValue": "",
                         "format": "",
-                        "i18n_properties": ["placeholder", "prefix", "suffix"],
+                        "i18n_properties": [
+                            "placeholder",
+                            "prefix",
+                            "suffix"
+                        ],
                         "label": "Number of Features",
                         "max": "",
                         "min": "",
@@ -738,7 +744,9 @@
                 {
                     "card_id": "a0c7cec6-1401-11f0-acd5-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Feature Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -758,7 +766,9 @@
                 {
                     "card_id": "a6995f93-272c-4548-83c5-5ba11fbdc364",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Member Role(s)",
                         "placeholder": {
                             "en": "Select an option"
@@ -778,7 +788,9 @@
                 {
                     "card_id": "e5917cc0-6327-42ee-8643-e076e6afca55",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Site Visit Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -804,7 +816,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Document Description",
                         "maxLength": "250",
                         "placeholder": {
@@ -832,7 +846,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Image Caption",
                         "maxLength": "80",
                         "placeholder": {
@@ -860,7 +876,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Copyright",
                         "maxLength": "80",
                         "placeholder": {
@@ -888,7 +906,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Site Visit Description",
                         "maxLength": null,
                         "placeholder": {
@@ -910,7 +930,9 @@
                 {
                     "card_id": "962503ce-61ab-11f0-be7c-3a7a4e6803c5",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "General Remark Source",
                         "placeholder": {
                             "en": "Select an option"
@@ -936,7 +958,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Image Feature(s)",
                         "maxLength": "80",
                         "placeholder": {
@@ -986,7 +1010,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Archaeological Culture Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -1008,7 +1034,9 @@
                 {
                     "card_id": "fab4bca8-1408-11f0-9e93-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Archaeological Culture Name",
                         "placeholder": {
                             "en": "Select an option"
@@ -1029,7 +1057,9 @@
                     "card_id": "a6995f93-272c-4548-83c5-5ba11fbdc364",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Team Member",
                         "placeholder": {
                             "en": "Select a person"
@@ -1047,32 +1077,12 @@
                     "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
                 },
                 {
-                    "card_id": "9eb5c3db-3087-4582-96d8-3584b060e908",
-                    "config": {
-                        "dateFormat": "YYYY",
-                        "defaultValue": "",
-                        "label": "Reference Year",
-                        "maxDate": false,
-                        "minDate": false,
-                        "placeholder": "Enter date",
-                        "uneditable": false,
-                        "viewMode": "days"
-                    },
-                    "id": "358d1523-3e23-4815-9ab9-4bb7e7148203",
-                    "label": {
-                        "en": "Reference Year"
-                    },
-                    "node_id": "583ad2f9-2320-403d-9311-186df231145e",
-                    "sortorder": 2,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                },
-                {
                     "card_id": "e5917cc0-6327-42ee-8643-e076e6afca55",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Non-Permit Affiliation",
                         "placeholder": {
                             "en": "Select an option"
@@ -1098,7 +1108,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Feature Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -1126,7 +1138,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Stratigraphy Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -1154,7 +1168,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "General Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -1182,7 +1198,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Biogeography Description",
                         "maxLength": null,
                         "placeholder": {
@@ -1205,7 +1223,9 @@
                     "card_id": "e5917cc0-6327-42ee-8643-e076e6afca55",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Site Form Author(s)",
                         "placeholder": {
                             "en": "Select a person"
@@ -1242,7 +1262,9 @@
                 {
                     "card_id": "4c611685-0f1a-442d-b938-c4f95fa732ee",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Biogeography Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -1325,7 +1347,9 @@
                     "card_id": "e5917cc0-6327-42ee-8643-e076e6afca55",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "HCA Permit",
                         "placeholder": {
                             "en": "Select permit"
@@ -1351,7 +1375,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Location and Access",
                         "maxLength": null,
                         "placeholder": {
@@ -1371,27 +1397,6 @@
                     "widget_id": "10000000-0000-0000-0000-000000000005"
                 },
                 {
-                    "card_id": "9eb5c3db-3087-4582-96d8-3584b060e908",
-                    "config": {
-                        "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
-                        "label": "Author(s)",
-                        "placeholder": {
-                            "en": "Select a person"
-                        },
-                        "uneditable": false
-                    },
-                    "id": "6617399d-6738-4dcb-ae57-45c4d0a04178",
-                    "label": {
-                        "en": "Author(s)"
-                    },
-                    "node_id": "727502b4-cac9-4c58-8882-56d2bdff4bbb",
-                    "sortorder": 3,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
-                },
-                {
                     "card_id": "6d906048-140d-11f0-b9bb-0242ac170007",
                     "config": {
                         "defaultValue": {
@@ -1400,7 +1405,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Site Name Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -1428,7 +1435,9 @@
                                 "value": "Enter text"
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Site Name",
                         "maxLength": "250",
                         "placeholder": {
@@ -1450,7 +1459,9 @@
                 {
                     "card_id": "6d906048-140d-11f0-b9bb-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Site Name Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -1471,7 +1482,9 @@
                     "card_id": "6d906048-140d-11f0-b9bb-0242ac170007",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Assigned or Reported By",
                         "placeholder": {
                             "en": "Select a person"
@@ -1513,7 +1526,9 @@
                 {
                     "card_id": "6f96fa96-5049-11f0-91cd-0242ac170006",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Ancestral Remains Status",
                         "placeholder": {
                             "en": "Select an option"
@@ -1533,7 +1548,9 @@
                 {
                     "card_id": "6f96fa96-5049-11f0-91cd-0242ac170006",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Ancestral Remains Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -1559,7 +1576,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Ancestral Remains Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -1600,7 +1619,11 @@
                     "config": {
                         "defaultValue": "",
                         "format": "",
-                        "i18n_properties": ["placeholder", "prefix", "suffix"],
+                        "i18n_properties": [
+                            "placeholder",
+                            "prefix",
+                            "suffix"
+                        ],
                         "label": "Minimum # Individuals",
                         "max": "",
                         "min": "",
@@ -1631,7 +1654,9 @@
                 {
                     "card_id": "e154ab8d-4f8b-4766-8614-aa2d48727792",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Document Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -1657,7 +1682,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Archaeology Branch Recommendations",
                         "maxLength": null,
                         "placeholder": {
@@ -1680,7 +1707,9 @@
                     "card_id": "e5917cc0-6327-42ee-8643-e076e6afca55",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Borden Number",
                         "placeholder": {
                             "en": "Select a site"
@@ -1720,34 +1749,6 @@
                     "widget_id": "10000000-0000-0000-0000-000000000004"
                 },
                 {
-                    "card_id": "9eb5c3db-3087-4582-96d8-3584b060e908",
-                    "config": {
-                        "defaultValue": {
-                            "en": {
-                                "direction": "ltr",
-                                "value": ""
-                            }
-                        },
-                        "i18n_properties": ["placeholder"],
-                        "label": "Reference Remarks",
-                        "maxLength": "",
-                        "placeholder": {
-                            "en": "Enter text"
-                        },
-                        "uneditable": false,
-                        "width": "100%"
-                    },
-                    "id": "83120985-82b0-49b7-a0f2-2e920ab26de4",
-                    "label": {
-                        "en": "Reference Remarks"
-                    },
-                    "node_id": "b47c96e1-921e-4358-81fa-b159cd5f05c8",
-                    "sortorder": 4,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000005"
-                },
-                {
                     "card_id": "15f3be27-7841-4672-9c7f-72eff82cd4de",
                     "config": {
                         "defaultValue": {
@@ -1756,7 +1757,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Image Photographer",
                         "maxLength": "80",
                         "placeholder": {
@@ -1784,7 +1787,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Recorder\u2019s Recommendations",
                         "maxLength": null,
                         "placeholder": {
@@ -1806,7 +1811,9 @@
                 {
                     "card_id": "a1042450-ab0c-4fda-96a5-deec2e6bcd1e",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Cultural Material Status",
                         "placeholder": {
                             "en": "Select an option"
@@ -1848,7 +1855,11 @@
                     "config": {
                         "defaultValue": "",
                         "format": "",
-                        "i18n_properties": ["placeholder", "prefix", "suffix"],
+                        "i18n_properties": [
+                            "placeholder",
+                            "prefix",
+                            "suffix"
+                        ],
                         "label": "Number of Artifacts",
                         "max": "",
                         "min": "",
@@ -1879,7 +1890,9 @@
                 {
                     "card_id": "45aa71cc-8aab-4157-bbe7-732e478e8e31",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Typology",
                         "placeholder": {
                             "en": "Select an option"
@@ -1919,7 +1932,9 @@
                 {
                     "card_id": "15f3be27-7841-4672-9c7f-72eff82cd4de",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Image Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -1945,7 +1960,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Biogeography Name",
                         "maxLength": null,
                         "placeholder": {
@@ -1989,7 +2006,9 @@
                 {
                     "card_id": "c1f56d2e-140b-11f0-898b-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "From Date Calendar",
                         "placeholder": {
                             "en": "Select an option"
@@ -2009,7 +2028,9 @@
                 {
                     "card_id": "c1f56d2e-140b-11f0-898b-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "From Date Qualifier",
                         "placeholder": {
                             "en": "Select an option"
@@ -2029,7 +2050,9 @@
                 {
                     "card_id": "c1f56d2e-140b-11f0-898b-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "To Date Qualifier",
                         "placeholder": {
                             "en": "Select an option"
@@ -2049,7 +2072,9 @@
                 {
                     "card_id": "c1f56d2e-140b-11f0-898b-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "To Date Calendar",
                         "placeholder": {
                             "en": "Select an option"
@@ -2075,7 +2100,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Chronology Source",
                         "maxLength": "250",
                         "placeholder": {
@@ -2120,7 +2147,9 @@
                     "card_id": "c1f56d2e-140b-11f0-898b-0242ac170007",
                     "config": {
                         "defaultValue": "",
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Event",
                         "options": [],
                         "placeholder": {
@@ -2169,7 +2198,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Chronology Remarks",
                         "maxLength": "250",
                         "placeholder": {
@@ -2191,7 +2222,9 @@
                 {
                     "card_id": "c1f56d2e-140b-11f0-898b-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Dating Method",
                         "placeholder": {
                             "en": "Select an option"
@@ -2261,7 +2294,9 @@
                     "card_id": "290cd148-e9a9-45c9-b649-065e59e893fa",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Assigned or Reported By",
                         "placeholder": {
                             "en": "Select a person"
@@ -2281,7 +2316,9 @@
                 {
                     "card_id": "cf40f022-13f0-11f0-9404-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Edit Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -2307,7 +2344,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Accuracy Remarks",
                         "maxLength": "500",
                         "placeholder": {
@@ -2335,7 +2374,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Source Notes",
                         "maxLength": null,
                         "placeholder": {
@@ -2410,7 +2451,9 @@
                 {
                     "card_id": "a1042450-ab0c-4fda-96a5-deec2e6bcd1e",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Cultural Material Type",
                         "placeholder": {
                             "en": "Select an option"
@@ -2458,7 +2501,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Temporary Number",
                         "maxLength": "125",
                         "placeholder": {
@@ -2486,7 +2531,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Typology Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -2506,54 +2553,6 @@
                     "widget_id": "10000000-0000-0000-0000-000000000005"
                 },
                 {
-                    "card_id": "9eb5c3db-3087-4582-96d8-3584b060e908",
-                    "config": {
-                        "defaultValue": {
-                            "en": {
-                                "direction": "ltr",
-                                "value": ""
-                            }
-                        },
-                        "i18n_properties": ["placeholder"],
-                        "label": "Reference Title",
-                        "maxLength": "",
-                        "placeholder": {
-                            "en": "Enter text"
-                        },
-                        "uneditable": false,
-                        "width": "100%"
-                    },
-                    "id": "d9ab2738-eb78-4542-97fe-f2e78b169fdf",
-                    "label": {
-                        "en": "Reference Title"
-                    },
-                    "node_id": "b0cb724b-aa73-4dd5-88c1-a2baab71615c",
-                    "sortorder": 1,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
-                },
-                {
-                    "card_id": "9eb5c3db-3087-4582-96d8-3584b060e908",
-                    "config": {
-                        "i18n_properties": ["placeholder"],
-                        "label": "Reference Type",
-                        "placeholder": {
-                            "en": "Select an option"
-                        },
-                        "uneditable": false
-                    },
-                    "id": "e3057c3e-5d94-4e6d-a720-b0bf8324b5d6",
-                    "label": {
-                        "en": "Reference Type"
-                    },
-                    "node_id": "7136804f-46c3-4229-bc16-aad1842769fb",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "19e56148-82b8-47eb-b66e-f6243639a1a8"
-                },
-                {
                     "card_id": "a1042450-ab0c-4fda-96a5-deec2e6bcd1e",
                     "config": {
                         "defaultValue": {
@@ -2562,7 +2561,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Cultural Material Details",
                         "maxLength": null,
                         "placeholder": {
@@ -2582,30 +2583,12 @@
                     "widget_id": "10000000-0000-0000-0000-000000000005"
                 },
                 {
-                    "card_id": "9eb5c3db-3087-4582-96d8-3584b060e908",
-                    "config": {
-                        "acceptedFiles": "",
-                        "defaultValue": [],
-                        "label": "Reference File",
-                        "maxFilesize": "1024",
-                        "rerender": true,
-                        "uneditable": false
-                    },
-                    "id": "f3ab9912-db0d-4d5e-a110-4059c7aa3ef0",
-                    "label": {
-                        "en": "Reference File"
-                    },
-                    "node_id": "57c9178c-c1eb-41f8-ad5e-f40230cdad9b",
-                    "sortorder": 5,
-                    "source_identifier_id": null,
-                    "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000019"
-                },
-                {
                     "card_id": "6f96fa96-5049-11f0-91cd-0242ac170006",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Repository",
                         "placeholder": {
                             "en": "Select an option"
@@ -2625,7 +2608,9 @@
                 {
                     "card_id": "fb55932c-140c-11f0-b9bb-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Disturbance Cause",
                         "placeholder": {
                             "en": "Select an option"
@@ -2645,7 +2630,9 @@
                 {
                     "card_id": "fb55932c-140c-11f0-b9bb-0242ac170007",
                     "config": {
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "When",
                         "placeholder": {
                             "en": "Select an option"
@@ -2671,7 +2658,9 @@
                                 "value": ""
                             }
                         },
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Disturbance Remarks",
                         "maxLength": null,
                         "placeholder": {
@@ -2694,7 +2683,9 @@
                     "card_id": "a1042450-ab0c-4fda-96a5-deec2e6bcd1e",
                     "config": {
                         "defaultResourceInstance": [],
-                        "i18n_properties": ["placeholder"],
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
                         "label": "Repository",
                         "placeholder": {
                             "en": "Select an option (if applicable)"
@@ -2945,16 +2936,6 @@
                 },
                 {
                     "description": null,
-                    "domainnode_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "edgeid": "38d43919-a4de-4114-a283-967b6e5e40c7",
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "name": null,
-                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
-                    "rangenode_id": "57c9178c-c1eb-41f8-ad5e-f40230cdad9b",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
                     "domainnode_id": "55f5927c-8279-4864-ba1d-2f288ca46fcf",
                     "edgeid": "38fc40eb-00a1-4476-bb8b-8800207c52ae",
                     "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
@@ -2971,16 +2952,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L47_has_comment",
                     "rangenode_id": "c98387af-e430-4317-b222-9f2191194817",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "edgeid": "3b4cd4f8-29be-4d48-9fc3-b6338b794ada",
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P92i_was_brought_into_existence_by",
-                    "rangenode_id": "583ad2f9-2320-403d-9311-186df231145e",
                     "source_identifier_id": null
                 },
                 {
@@ -3041,16 +3012,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P70i_is_documented_in",
                     "rangenode_id": "b03790fe-df58-11ef-8fa3-0242ac170009",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "edgeid": "56fc24f6-4d1b-49f1-a71e-fb65a23ab9b6",
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "name": null,
-                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
-                    "rangenode_id": "b0cb724b-aa73-4dd5-88c1-a2baab71615c",
                     "source_identifier_id": null
                 },
                 {
@@ -3251,16 +3212,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of",
                     "rangenode_id": "9bd92cab-7995-4940-9547-073e2eb505ac",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "edgeid": "7c9c75e3-ba2f-423e-b752-914892a40413",
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "rangenode_id": "7136804f-46c3-4229-bc16-aad1842769fb",
                     "source_identifier_id": null
                 },
                 {
@@ -3615,16 +3566,6 @@
                 },
                 {
                     "description": null,
-                    "domainnode_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "edgeid": "cc73823d-8043-4fc3-8f75-a698251ff624",
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "name": null,
-                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L33_has_maker",
-                    "rangenode_id": "727502b4-cac9-4c58-8882-56d2bdff4bbb",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
                     "domainnode_id": "cf40edc0-13f0-11f0-9404-0242ac170007",
                     "edgeid": "cf410d14-13f0-11f0-9404-0242ac170007",
                     "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
@@ -3721,16 +3662,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P116_starts",
                     "rangenode_id": "745b0462-140f-11f0-8419-0242ac170007",
-                    "source_identifier_id": null
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "edgeid": "efb4068b-9cb1-4004-a1c5-30a358eafbe0",
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of",
-                    "rangenode_id": "b47c96e1-921e-4358-81fa-b159cd5f05c8",
                     "source_identifier_id": null
                 },
                 {
@@ -4028,7 +3959,10 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": ["trueLabel", "falseLabel"],
+                        "i18n_properties": [
+                            "trueLabel",
+                            "falseLabel"
+                        ],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -4505,60 +4439,7 @@
                     "nodeid": "55f5927c-8279-4864-ba1d-2f288ca46fcf",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E84_Information_Carrier",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P130i_features_are_also_found_on",
-                    "sortorder": 1,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "reference_file",
-                    "config": {
-                        "activateMax": false,
-                        "imagesOnly": false,
-                        "maxFileSize": null,
-                        "maxFiles": 1
-                    },
-                    "datatype": "file-list",
-                    "description": null,
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference File",
-                    "nodegroup_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "nodeid": "57c9178c-c1eb-41f8-ad5e-f40230cdad9b",
-                    "ontologyclass": "http://www.ics.forth.gr/isl/CRMdig/D13_Digital_Information_Carrier",
-                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "reference_year",
-                    "config": {
-                        "dateFormat": "YYYY"
-                    },
-                    "datatype": "date",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "REF_YEAR",
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference Year",
-                    "nodegroup_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "nodeid": "583ad2f9-2320-403d-9311-186df231145e",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E63_Beginning_of_Existence",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P92i_was_brought_into_existence_by",
-                    "sortorder": 3,
+                    "sortorder": 2,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -4733,7 +4614,10 @@
                         "falseLabel": {
                             "en": "Additional Image"
                         },
-                        "i18n_properties": ["trueLabel", "falseLabel"],
+                        "i18n_properties": [
+                            "trueLabel",
+                            "falseLabel"
+                        ],
                         "trueLabel": {
                             "en": "Primary Image"
                         }
@@ -4783,8 +4667,21 @@
                 },
                 {
                     "alias": "publication_reference",
-                    "config": {},
-                    "datatype": "semantic",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "3caf329f-b8f7-11e6-84a5-026d961c88e6",
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "Publication",
+                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance-list",
                     "description": "{\"en\": \"\"}",
                     "exportable": false,
                     "fieldname": null,
@@ -5055,7 +4952,10 @@
                         "falseLabel": {
                             "en": "No"
                         },
-                        "i18n_properties": ["trueLabel", "falseLabel"],
+                        "i18n_properties": [
+                            "trueLabel",
+                            "falseLabel"
+                        ],
                         "trueLabel": {
                             "en": "Yes"
                         }
@@ -5157,32 +5057,6 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "reference_type",
-                    "config": {
-                        "controlledList": "74e02e4f-8587-5cfa-93b4-d81539f023dd",
-                        "multiValue": false
-                    },
-                    "datatype": "reference",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "REF_TYPE",
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": true,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference Type",
-                    "nodegroup_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "nodeid": "7136804f-46c3-4229-bc16-aad1842769fb",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "sortorder": 0,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
                     "alias": "stratigraphy",
                     "config": {
                         "en": ""
@@ -5204,42 +5078,6 @@
                     "ontologyclass": "http://www.ics.forth.gr/isl/CRMsci/S4_Observation",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P9_consists_of",
                     "sortorder": 2,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "reference_authors",
-                    "config": {
-                        "graphs": [
-                            {
-                                "graphid": "605b0bbc-8661-4cf2-b340-df743a8c5f89",
-                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
-                                "name": "Contributor",
-                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
-                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
-                                "useOntologyRelationship": false
-                            }
-                        ],
-                        "searchDsl": "",
-                        "searchString": ""
-                    },
-                    "datatype": "resource-instance-list",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "REF_AUTHOR",
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference Authors",
-                    "nodegroup_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "nodeid": "727502b4-cac9-4c58-8882-56d2bdff4bbb",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E39_Actor",
-                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L33_has_maker",
-                    "sortorder": 1,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -5712,7 +5550,7 @@
                     "nodeid": "a6536975-292e-47d1-8ebe-7e83092438bd",
                     "ontologyclass": "http://www.ics.forth.gr/isl/CRMdig/D13_Digital_Information_Carrier",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of",
-                    "sortorder": 0,
+                    "sortorder": 1,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -5861,52 +5699,6 @@
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E32_Authority_Document",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P70i_is_documented_in",
                     "sortorder": 4,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "reference_title",
-                    "config": {},
-                    "datatype": "string",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "REF_TITLE",
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": true,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference Title",
-                    "nodegroup_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "nodeid": "b0cb724b-aa73-4dd5-88c1-a2baab71615c",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E41_Appellation",
-                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
-                    "sortorder": 4,
-                    "source_identifier_id": null,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "reference_remarks",
-                    "config": {},
-                    "datatype": "string",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "REF_REMARK",
-                    "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "is_immutable": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Reference Remarks",
-                    "nodegroup_id": "6ac56e05-8c19-4ef3-9f3b-f5921c278e17",
-                    "nodeid": "b47c96e1-921e-4358-81fa-b159cd5f05c8",
-                    "ontologyclass": "http://www.ics.forth.gr/isl/CRMdig/D29_Annotation_Object",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of",
-                    "sortorder": 0,
                     "source_identifier_id": null,
                     "sourcebranchpublication_id": null
                 },
@@ -6690,7 +6482,10 @@
                         "falseLabel": {
                             "en": "Non-permit"
                         },
-                        "i18n_properties": ["trueLabel", "falseLabel"],
+                        "i18n_properties": [
+                            "trueLabel",
+                            "falseLabel"
+                        ],
                         "trueLabel": {
                             "en": "Permit"
                         }
@@ -6848,9 +6643,9 @@
             "publication": {
                 "graph_id": "2da1c15f-1ab6-4122-9dbc-d10da693ac79",
                 "most_recent_edit_id": null,
-                "notes": null,
-                "publicationid": "919fd84f-2fb0-4b94-ae31-d6d370867a41",
-                "published_time": "2026-03-10T06:04:46.387"
+                "notes": "Replace individual publication reference attributes with resource-instance-list",
+                "publicationid": "3c8e1869-1256-4a09-8616-9baf826d9ae3",
+                "published_time": "2026-05-13T22:32:50.208"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],
@@ -6951,9 +6746,9 @@
         }
     ],
     "metadata": {
-        "db": "PostgreSQL 16.4 (Debian 16.4-1.pgdg110+2) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
-        "git hash": "a67a23c71 2025-08-14 16:46:56 -0700",
+        "db": "PostgreSQL 16.3 (Debian 16.3-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
+        "git hash": "d5a4f8fb2c 2026-04-22 06:33:18 -0700",
         "os": "Linux",
-        "os version": "6.6.87.2-microsoft-standard-WSL2"
+        "os version": "6.12.76-linuxkit"
     }
 }

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/ArchaeologicalSiteDetails.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/ArchaeologicalSiteDetails.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
 import DetailsSection from '@/bcap/components/DetailsSection/DetailsSection.vue';
 import {
     useResourceData,
@@ -18,6 +18,7 @@ import Section9 from '@/bcap/components/pages/details/ArchaeologicalSite/section
 import type { DetailsData } from '@/bcap/types.ts';
 import type { ArchaeologySiteSchema } from '@/bcap/schema/ArchaeologySiteSchema.ts';
 import type { SiteVisitSchema } from '@/bcap/schema/SiteVisitSchema.ts';
+import type { PublicationSchema } from '@/bcap/schema/PublicationSchema.ts';
 import type { HriaDiscontinuedDataSchema } from '@/bcap/schema/HriaDiscontinuedDataSchema.ts';
 import type { SiteLocationTile } from '@/bcap/schema/ArchaeologySiteSchema.ts';
 import DataTable from 'primevue/datatable';
@@ -49,6 +50,12 @@ const { data: currentData, loading: siteDataLoading } =
 const { data: siteVisitData, loading: siteVisitDataLoading } =
     useRelatedResourceData<SiteVisitSchema>('site_visit', resourceId);
 
+const { data: publicationData, loading: publicationDataLoading } =
+    useRelatedResourceData<PublicationSchema>(
+        'archaeological_site',
+        resourceId,
+    );
+
 const { data: childSiteData, loading: childSiteDataLoading } =
     useRelatedResourceData<ArchaeologySiteSchema>(
         'archaeological_site',
@@ -61,6 +68,15 @@ const { data: hriaDiscontinuedData, loading: hriaDataLoading } =
         resourceId,
         true,
     );
+
+watch(currentData, () => {
+    if (currentData.value) {
+        console.log(
+            'Current archaeological site data updated:',
+            currentData.value,
+        );
+    }
+});
 
 const typedCurrentData = computed(
     () => currentData.value as ArchaeologySiteSchema | undefined,
@@ -76,6 +92,10 @@ const typedChildSiteData = computed(
 
 const typedHriaData = computed(
     () => hriaDiscontinuedData.value as HriaDiscontinuedDataSchema | undefined,
+);
+
+const typedPublicationData = computed(
+    () => publicationData.value as PublicationSchema | undefined,
 );
 </script>
 
@@ -166,7 +186,10 @@ const typedHriaData = computed(
         <Section9
             :data="typedCurrentData?.aliased_data?.related_documents"
             :hria-data="typedHriaData"
-            :loading="siteDataLoading || hriaDataLoading"
+            :publication-data="typedPublicationData"
+            :loading="
+                siteDataLoading || hriaDataLoading || publicationDataLoading
+            "
             :force-collapsed="props.forceCollapsed"
             :show-audit-fields="props.showAuditFields"
             :edit-log-data="props.editLogData"

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/ArchaeologicalSiteDetails.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/ArchaeologicalSiteDetails.vue
@@ -51,10 +51,7 @@ const { data: siteVisitData, loading: siteVisitDataLoading } =
     useRelatedResourceData<SiteVisitSchema>('site_visit', resourceId);
 
 const { data: publicationData, loading: publicationDataLoading } =
-    useRelatedResourceData<PublicationSchema>(
-        'archaeological_site',
-        resourceId,
-    );
+    useRelatedResourceData<PublicationSchema>('publication', resourceId);
 
 const { data: childSiteData, loading: childSiteDataLoading } =
     useRelatedResourceData<ArchaeologySiteSchema>(

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/ArchaeologicalSiteDetails.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/ArchaeologicalSiteDetails.vue
@@ -92,7 +92,7 @@ const typedHriaData = computed(
 );
 
 const typedPublicationData = computed(
-    () => publicationData.value as PublicationSchema | undefined,
+    () => publicationData.value as PublicationSchema[] | undefined,
 );
 </script>
 

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection9.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection9.vue
@@ -94,17 +94,8 @@ const publicationColumns: ColumnDefinition[] = [
                 .join(', '),
     },
     {
-        label: 'Remarks',
-        field: 'reference_remarks',
-        displayFunction: (value: AliasedTileDataWithAudit) => {
-            const publication_ref = currentData?.value?.publication_reference;
-            const remark = publication_ref?.filter(
-                (ref) =>
-                    ref?.aliased_data?.publication?.node_value?.[0]
-                        .resourceId === value.resourceinstance,
-            )?.[0];
-            return `${remark?.aliased_data?.reference_remarks?.display_value}`;
-        },
+        label: 'Remarks2',
+        field: 'publication_remarks',
     },
 ];
 

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection9.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection9.vue
@@ -94,7 +94,7 @@ const publicationColumns: ColumnDefinition[] = [
                 .join(', '),
     },
     {
-        label: 'Remarks2',
+        label: 'Remarks',
         field: 'publication_remarks',
     },
 ];

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection9.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection9.vue
@@ -4,9 +4,16 @@ import DetailsSection from '@/bcap/components/DetailsSection/DetailsSection.vue'
 import EmptyState from '@/bcap/components/EmptyState.vue';
 import StandardDataTable from '@/bcgov_arches_common/components/StandardDataTable/StandardDataTable.vue';
 import { useTileEditLog } from '@/bcgov_arches_common/composables/useTileEditLog.ts';
-import type { EditLogData } from '@/bcgov_arches_common/types.ts';
+import type {
+    AliasedTileDataWithAudit,
+    EditLogData,
+} from '@/bcgov_arches_common/types.ts';
 import 'primeicons/primeicons.css';
-import type { PublicationSchema } from '@/bcap/schema/PublicationSchema.ts';
+import type {
+    PublicationDetailsTile,
+    PublicationSchema,
+    AuthorsTile,
+} from '@/bcap/schema/PublicationSchema.ts';
 import type { RelatedDocumentsTile } from '@/bcap/schema/ArchaeologySiteSchema.ts';
 import type {
     HriaDiscontinuedDataSchema,
@@ -20,7 +27,7 @@ const props = withDefaults(
     defineProps<{
         data: RelatedDocumentsTile | undefined;
         hriaData?: HriaDiscontinuedDataSchema;
-        publicationData?: PublicationSchema;
+        publicationData?: PublicationSchema[] | undefined;
         loading?: boolean;
         languageCode?: string;
         forceCollapsed?: boolean;
@@ -51,12 +58,54 @@ const relatedDocumentsData = computed(() => {
     return expandDocumentRows(docsArray, 'related_site_documents');
 });
 
-const referencesColumns: ColumnDefinition[] = [
-    { field: 'reference_type', label: 'Reference Type' },
-    { field: 'reference_title', label: 'Title' },
-    { field: 'reference_year', label: 'Year' },
-    { field: 'reference_authors', label: 'Author(s)' },
-    { field: 'reference_remarks', label: 'Remarks' },
+type PublicationDetailsTileWithAuthors = AliasedTileDataWithAudit &
+    PublicationDetailsTile & {
+        aliased_data: PublicationDetailsTile['aliased_data'] & {
+            authors: AuthorsTile | undefined;
+        };
+    };
+const publicationReferencesData = computed<PublicationDetailsTileWithAuthors[]>(
+    () => {
+        return (props.publicationData ?? []).map((publication) => {
+            let data = publication.aliased_data
+                .publication_details as PublicationDetailsTileWithAuthors;
+            data.aliased_data.authors = publication.aliased_data.authors;
+            return data;
+        });
+    },
+);
+
+const publicationColumns: ColumnDefinition[] = [
+    {
+        field: 'publication_type',
+        label: 'Reference Type',
+    },
+    { field: 'title', label: 'Title' },
+    {
+        field: 'year_of_publication',
+        label: 'Year',
+    },
+    {
+        field: 'authors.0.aliased_data.authors',
+        label: 'Author(s)',
+        displayFunction: (value: AliasedTileDataWithAudit) =>
+            (value.aliased_data?.authors as AuthorsTile[])
+                ?.map((author) => author?.aliased_data?.authors?.display_value)
+                .join(', '),
+    },
+    {
+        label: 'Remarks',
+        field: 'reference_remarks',
+        displayFunction: (value: AliasedTileDataWithAudit) => {
+            const publication_ref = currentData?.value?.publication_reference;
+            const remark = publication_ref?.filter(
+                (ref) =>
+                    ref?.aliased_data?.publication?.node_value?.[0]
+                        .resourceId === value.resourceinstance,
+            )?.[0];
+            return `${remark?.aliased_data?.reference_remarks?.display_value}`;
+        },
+    },
 ];
 
 const relatedDocumentsColumns = computed<ColumnDefinition[]>(() => {
@@ -153,7 +202,6 @@ const hasOtherMaps = computed(() => {
 </script>
 
 <template>
-    <div>{{ publicationData }}</div>
     <DetailsSection
         section-title="9. References & Related Documents"
         :loading="props.loading"
@@ -170,8 +218,8 @@ const hasOtherMaps = computed(() => {
                 <template #sectionContent>
                     <StandardDataTable
                         v-if="hasReferences"
-                        :table-data="currentData?.publication_reference ?? []"
-                        :column-definitions="referencesColumns"
+                        :table-data="publicationReferencesData"
+                        :column-definitions="publicationColumns"
                         :initial-sort-field-index="2"
                     />
                     <EmptyState

--- a/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection9.vue
+++ b/bcap/src/bcap/components/pages/details/ArchaeologicalSite/sections/DetailsSection9.vue
@@ -6,6 +6,7 @@ import StandardDataTable from '@/bcgov_arches_common/components/StandardDataTabl
 import { useTileEditLog } from '@/bcgov_arches_common/composables/useTileEditLog.ts';
 import type { EditLogData } from '@/bcgov_arches_common/types.ts';
 import 'primeicons/primeicons.css';
+import type { PublicationSchema } from '@/bcap/schema/PublicationSchema.ts';
 import type { RelatedDocumentsTile } from '@/bcap/schema/ArchaeologySiteSchema.ts';
 import type {
     HriaDiscontinuedDataSchema,
@@ -19,6 +20,7 @@ const props = withDefaults(
     defineProps<{
         data: RelatedDocumentsTile | undefined;
         hriaData?: HriaDiscontinuedDataSchema;
+        publicationData?: PublicationSchema;
         loading?: boolean;
         languageCode?: string;
         forceCollapsed?: boolean;
@@ -32,6 +34,7 @@ const props = withDefaults(
         editLogData: () => ({}),
         showAuditFields: false,
         hriaData: undefined,
+        publicationData: undefined,
     },
 );
 
@@ -150,6 +153,7 @@ const hasOtherMaps = computed(() => {
 </script>
 
 <template>
+    <div>{{ publicationData }}</div>
     <DetailsSection
         section-title="9. References & Related Documents"
         :loading="props.loading"

--- a/bcap/src/bcap/schema/ArchaeologySiteSchema.ts
+++ b/bcap/src/bcap/schema/ArchaeologySiteSchema.ts
@@ -8,6 +8,7 @@ import type { AliasedGeojsonFeatureCollectionNode } from '@/bcgov_arches_common/
 import type { ReferenceSelectValue } from '@/arches_controlled_lists/datatypes/reference-select/types.ts';
 import type { DateValue } from '@/arches_component_lab/datatypes/date/types.ts';
 import type { StringValue } from '@/arches_component_lab/datatypes/string/types.ts';
+import type { ResourceInstanceListValue } from '@/arches_component_lab/datatypes/resource-instance-list/types.ts';
 
 export interface SpatialAccuracyEntry extends AliasedTileData {
     aliased_data: {
@@ -251,6 +252,7 @@ export interface RemarksAndRestrictedInformationTile extends AliasedTileData {
 
 export interface PublicationReferenceTile extends AliasedTileData {
     aliased_data: {
+        publication?: ResourceInstanceListValue;
         reference_type?: AliasedNodeData;
         reference_title?: AliasedNodeData;
         reference_year?: AliasedNodeData;

--- a/bcap/src/bcap/schema/PublicationSchema.ts
+++ b/bcap/src/bcap/schema/PublicationSchema.ts
@@ -39,10 +39,13 @@ export interface KeywordTile extends AliasedTileData {
 export interface PublicationDetailsTile extends AliasedTileData {
     aliased_data: {
         publication_type?: AliasedNodeData;
-        title?: AliasedNodeData;
+        title?: StringValue;
         year_of_publication?: DateValue;
-        reference_authors?: AliasedNodeData;
-        reference_remarks?: AliasedNodeData;
+        page_range_start?: AliasedNodeData;
+        page_range_end?: AliasedNodeData;
+        publication_remarks?: StringValue;
+        journal_or_volume_name?: AliasedNodeData;
+        other_journal_or_volume_name?: StringValue;
     };
 }
 export interface ReferenceLinkTile extends AliasedTileData {

--- a/bcap/src/bcap/schema/PublicationSchema.ts
+++ b/bcap/src/bcap/schema/PublicationSchema.ts
@@ -1,0 +1,67 @@
+import type {
+    AliasedNodeData,
+    AliasedTileData,
+} from '@/arches_component_lab/types.ts';
+import type { FileListValue } from '@/arches_component_lab/datatypes/file-list/types.ts';
+import type { ArchesResourceInstanceData } from '@/bcgov_arches_common/types.ts';
+import type { ReferenceSelectValue } from '@/arches_controlled_lists/datatypes/reference-select/types.ts';
+import type { DateValue } from '@/arches_component_lab/datatypes/date/types.ts';
+import type { StringValue } from '@/arches_component_lab/datatypes/string/types.ts';
+
+export interface AuthorsTile extends AliasedTileData {
+    aliased_data: {
+        authors?: ReferenceSelectValue;
+        other_authors_unlisted?: StringValue;
+    };
+}
+
+export interface CopyrightTypeTile extends AliasedTileData {
+    aliased_data: {
+        distribution_permitted?: AliasedNodeData;
+        signed_agreement?: AliasedNodeData;
+        agreement_text?: AliasedNodeData;
+        copyright_type?: AliasedNodeData;
+    };
+}
+
+export interface InformationCarrierTile extends AliasedTileData {
+    aliased_data: {
+        information_carrier?: FileListValue;
+    };
+}
+
+export interface KeywordTile extends AliasedTileData {
+    aliased_data: {
+        keyword?: AliasedNodeData;
+    };
+}
+
+export interface PublicationDetailsTile extends AliasedTileData {
+    aliased_data: {
+        publication_type?: AliasedNodeData;
+        title?: AliasedNodeData;
+        year_of_publication?: DateValue;
+        reference_authors?: AliasedNodeData;
+        reference_remarks?: AliasedNodeData;
+    };
+}
+export interface ReferenceLinkTile extends AliasedTileData {
+    aliased_data: {
+        archaeological_sites?: AliasedNodeData;
+        site_visits?: AliasedNodeData;
+        repositories?: AliasedNodeData;
+    };
+}
+
+type PublicationAliasedData = {
+    authors?: AuthorsTile;
+    copyright_type?: CopyrightTypeTile;
+    information_carrier?: InformationCarrierTile;
+    keyword: KeywordTile[];
+    publication_details?: PublicationDetailsTile;
+    reference_link?: ReferenceLinkTile;
+};
+
+export interface PublicationSchema extends ArchesResourceInstanceData<PublicationAliasedData> {
+    aliased_data: PublicationAliasedData;
+}

--- a/bcap/templates/views/components/functions/publication-descriptors.htm
+++ b/bcap/templates/views/components/functions/publication-descriptors.htm
@@ -1,0 +1,56 @@
+{% load i18n %}
+
+<div class="primary-descriptors-container">
+    <!-- Nav tabs -->
+    <ul class="nav nav-tabs card-nav-container" role="tablist">
+        <li role="presentation" class="active"><a href="#primary-descriptors-name"
+                                                  aria-controls="primary-descriptors-name" role="tab" data-toggle="tab">
+            {% trans "Display Name" %}</a></li>
+        <li role="presentation"><a href="#primary-descriptors-description"
+                                   aria-controls="primary-descriptors-description" role="tab" data-toggle="tab"> {% trans "Display Description" %}</a></li>
+        <li role="presentation"><a href="#primary-descriptors-map-popup" aria-controls="primary-descriptors-description"
+                                   role="tab" data-toggle="tab">{% trans "Map Popup" %}</a></li>
+        <li role="presentation" style="float:right; padding-right: 15px;"><a href="#reindex" aria-controls="reindex"
+                                                                             role="tab" data-toggle="tab">{% trans "Re-Index" %}</a></li>
+    </ul>
+
+    <div class="tab-content">
+        <div class="tab-pane primary-descriptors-panel active" role="tabpanel" id="primary-descriptors-name">
+            <div>This descriptor has no configuration</div>
+        </div>
+    </div>
+
+    <div class="tab-content">
+        <div class="tab-pane" role="tabpanel" id="primary-descriptors-description">
+            <div>This descriptor has no configuration</div>
+        </div>
+    </div>
+
+    <div class="tab-content">
+        <div class="tab-pane" role="tabpanel" id="primary-descriptors-map-popup">
+            <div>This descriptor has no configuration</div>
+        </div>
+    </div>
+
+    <div class="tab-pane" role="tabpanel" id="reindex">
+        <div class="row widget-container">
+            <div class="form-group">
+                <div class="relative">
+                    <i class="fa fa-exclamation-triangle" style="color: #f75d3f;"></i><span class="control-label"> {% trans "If you've made any changes to this function and there are resources already in the system, then you will need to reindex the resources to reflect your changes.  This process can take some time (potentially several minuetes or more).  Please be patient." %}</span>
+                </div>
+
+                <div class="col-xs-12">
+                    <a class="btn btn-sm btn-primary btn-labeled fa fa-refresh"
+                       style="float: right;margin-top: 6px;margin-right: 6px;"
+                       data-bind="visible: !loading(), click: reindexdb;">{% trans "Re-Index Resources Now" %}</a>
+                    <a class="btn btn-primary" href="#"
+                       style="float: right;margin-top: 6px;margin-right: 6px; padding:0px 5px 0px 0px;"
+                       data-bind="visible: loading">
+                        <i class="fa fa-spin fa-refresh" style="padding: 8px;"></i> {% trans "Re-Indexing..." %}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/bcap/templates/views/components/functions/publication-descriptors.htm
+++ b/bcap/templates/views/components/functions/publication-descriptors.htm
@@ -36,7 +36,7 @@
         <div class="row widget-container">
             <div class="form-group">
                 <div class="relative">
-                    <i class="fa fa-exclamation-triangle" style="color: #f75d3f;"></i><span class="control-label"> {% trans "If you've made any changes to this function and there are resources already in the system, then you will need to reindex the resources to reflect your changes.  This process can take some time (potentially several minuetes or more).  Please be patient." %}</span>
+                    <i class="fa fa-exclamation-triangle" style="color: #f75d3f;"></i><span class="control-label"> {% trans "If you've made any changes to this function and there are resources already in the system, then you will need to reindex the resources to reflect your changes.  This process can take some time (potentially several minutes or more).  Please be patient." %}</span>
                 </div>
 
                 <div class="col-xs-12">

--- a/bcap/util/aliases/publication.py
+++ b/bcap/util/aliases/publication.py
@@ -1,0 +1,32 @@
+from bcap.util.bcap_aliases import AbstractAliases
+
+
+class PublicationAliases(AbstractAliases):
+    AGREEMENT_TEXT = "agreement_text"
+    ARCHAEOLOGICAL_SITES = "archaeological_sites"
+    AUTHORS = "authors"
+    BC_INFORMATION_RESOURCE_MODEL = "bc_information_resource_model"
+    COPYRIGHT_TYPE = "copyright_type"
+    DISTRIBUTION_AGREEMENT = "distribution_agreement"
+    DISTRIBUTION_PERMITTED = "distribution_permitted"
+    INFORMATION_CARRIER = "information_carrier"
+    JOURNAL_OR_VOLUME_NAME = "journal_or_volume_name"
+    KEYWORD = "keyword"
+    OTHER_AUTHORS_UNLISTED = "other_authors_unlisted"
+    OTHER_JOURNAL_OR_VOLUME_NAME = "other_journal_or_volume_name"
+    PAGE_RANGE_END = "page_range_end"
+    PAGE_RANGE_START = "page_range_start"
+    PUBLICATION_DETAILS = "publication_details"
+    PUBLICATION_IDENTIFIER = "publication_identifier"
+    PUBLICATION_IDENTIFIER_TYPE = "publication_identifier_type"
+    PUBLICATION_TYPE = "publication_type"
+    REFERENCE_LINK = "reference_link"
+    REPOSITORIES = "repositories"
+    SIGNED_AGREEMENT = "signed_agreement"
+    SITE_VISITS = "site_visits"
+    TITLE = "title"
+    YEAR_OF_PUBLICATION = "year_of_publication"
+
+    @staticmethod
+    def get_aliases():
+        return AbstractAliases.get_dict(PublicationAliases)

--- a/bcap/util/bcap_aliases.py
+++ b/bcap/util/bcap_aliases.py
@@ -14,5 +14,6 @@ class GraphSlugs:
     ARCHAEOLOGICAL_SITE = "archaeological_site"
     HRIA_DISCONTINUED_DATA = "hria_discontinued_data"
     LEGISLATIVE_ACT = "legislative_act"
+    PUBLICATION = "publication"
     SITE_SUBMISSION = "site_submission"
     SITE_VISIT = "site_visit"

--- a/bcap/views/api.py
+++ b/bcap/views/api.py
@@ -187,11 +187,21 @@ class RelatedSiteVisits(ArchesModelAPIMixin, ListCreateAPIView):
                     as_representation=True,
                 ).select_related("graph")
 
-                qs = (
-                    qs.filter(parent_site__id__in=resource_ids_string)
-                    if self.graph_slug == "archaeological_site"
-                    else qs.filter(archaeological_site__id__in=resource_ids_string)
-                )
+                if self.graph_slug == "archaeological_site":
+                    qs = qs.filter(parent_site__id__in=resource_ids_string)
+                elif self.graph_slug == "publication":
+                    publication_ids = (
+                        ResourceXResource.objects.filter(
+                            from_resource_id__in=resource_ids_string
+                        )
+                        .values("to_resource_id")
+                        .all()
+                    )
+                    qs = qs.filter(
+                        resourceinstanceid__in=publication_ids
+                    ).select_related("graph")
+                else:
+                    qs = qs.filter(archaeological_site__id__in=resource_ids_string)
 
                 if Version(arches_version) >= Version("8.0"):
                     qs = qs.select_related("resource_instance_lifecycle_state")


### PR DESCRIPTION
- Moves the publication reference data to a new "Publication" model (taken from BCFMS)
- Updates Arch Site & Site Visit resource models to use Publication resource model
- Updatese Details page for above changes
- Minor changes to Permit Application resource model in support of BT session

closes: #1271

Must be merged with: bcgov-c/nr-bcap-etl#108