### PR TITLE
Python upgrade to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 USER root
 ENV PROJECT_NAME=bcap
 ## Setting default environment variables
@@ -12,6 +12,7 @@ ENV COMPONENT_LAB_ROOT=${WEB_ROOT}/arches-component-lab
 ENV QUERYSETS_ROOT=${WEB_ROOT}/arches-querysets
 ENV WHEELS=/wheels
 ENV PYTHONUNBUFFERED=1
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y make software-properties-common
 # Get the pre-built python wheels from the build environment
 RUN mkdir ${WEB_ROOT}
@@ -23,13 +24,12 @@ RUN mkdir ${WEB_ROOT}
 RUN set -ex \
   && RUN_DEPS=" \
   build-essential \
-  python3.11-dev \
-  mime-support \
+  python3-dev \
+  media-types \
   libgdal-dev \
   postgresql-client-16 \
-  python3.11 \
-  python3.11-distutils \
-  python3.11-venv \
+  python3 \
+  python3-venv \
   dos2unix \
   git \
   gettext \
@@ -41,8 +41,11 @@ RUN set -ex \
   && add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -sc)-pgdg main" \
   && apt-get update -y \
   && apt-get install -y --no-install-recommends $RUN_DEPS \
+  && apt-get remove -y python3-jwt python3-cryptography || true \
+  && apt-get autoremove -y \
+  && rm -f /usr/lib/python3.12/EXTERNALLY-MANAGED \
   && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-  && python3.11 get-pip.py \
+  && python3 get-pip.py \
   && apt-get install -y nodejs
 
 # Install Yarn components

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ ENV COMPONENT_LAB_ROOT=${WEB_ROOT}/arches-component-lab
 ENV QUERYSETS_ROOT=${WEB_ROOT}/arches-querysets
 ENV WHEELS=/wheels
 ENV PYTHONUNBUFFERED=1
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y make software-properties-common
 # Get the pre-built python wheels from the build environment
 RUN mkdir ${WEB_ROOT}

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ def get_user_list():
 4. Start and open the `bcap7-6` container in Docker Desktop
 5. Go to the "Exec" tab and run the following:
 ```
-python3.11 manage.py bc_test_users --refresh
+python3 manage.py bc_test_users --refresh
 ```
 6. Open the "Inspect" tab in the container
 7. `Ctrl + F` for `Networks` and look for `IPAddress`
@@ -169,7 +169,7 @@ python3.11 manage.py bc_test_users --refresh
 11. Go to the "Exec" tab and run the following:
 ```
 npm run build_development
-python3.11 manage.py setup_db
+python3 manage.py setup_db
 ```
 
 #### Authentication
@@ -224,11 +224,11 @@ docker cp bcap.sql bcap7-6:/tmp/bcap.sql
 createdb -U postgres -h postgres16-3_arches7-5-2 bcap
 psql -U postgres -h postgres16-3_arches7-5-2 -d bcap -c "CREATE EXTENSION IF NOT EXISTS postgis;"
 psql -U postgres -h postgres16-3_arches7-5-2 -d bcap -f /tmp/bcap.sql
-python3.11 manage.py es index_database
+python3 manage.py es index_database
 ```
 3. If you are having trouble with logins you might need to refresh your test user list
 ```
-python3.11 manage.py bc_test_users --refresh
+python3 manage.py bc_test_users --refresh
 ```
 
 ## Developing the UI using Vite
@@ -237,7 +237,7 @@ See [README.vite.md](./README.vite.md) for details about developing using the Vi
 ## Running Backend Unit Tests
 
 ```
-python3.11 manage.py test tests --pattern="*.py" --settings="tests.test_settings" --keepdb
+python3 manage.py test tests --pattern="*.py" --settings="tests.test_settings" --keepdb
 ```
 
 - `--keepdb` reuses the existing test database between runs to save time

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,7 +10,7 @@ else
 	PACKAGE_JSON_FOLDER=${ARCHES_ROOT}
 fi
 
-PYTHON_EXEC=python3.11
+PYTHON_EXEC=python3
 
 # Environmental Variables
 export DJANGO_PORT=${DJANGO_PORT:-8000}

--- a/docker/webpack/Dockerfile
+++ b/docker/webpack/Dockerfile
@@ -6,7 +6,6 @@ ENV APP_ROOT=${WEB_ROOT}/bcap
 ENV ARCHES_COMMON=${WEB_ROOT}/bcgov-arches-common
 ENV ARCHES_COMPONENT_LAB=${WEB_ROOT}/arches-component-lab
 ENV NODE_MAJOR=20
-ENV DEBIAN_FRONTEND=noninteractive
 RUN mkdir -p ${APP_ROOT}/bcap/webpack
 
 RUN apt-get update && apt-get install -y make software-properties-common && apt-get install -y ca-certificates curl gnupg && mkdir -p /etc/apt/keyrings

--- a/docker/webpack/Dockerfile
+++ b/docker/webpack/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 USER root
 ENV WEB_ROOT=/web_root
 ENV ARCHES_ROOT=${WEB_ROOT}/arches
@@ -6,6 +6,7 @@ ENV APP_ROOT=${WEB_ROOT}/bcap
 ENV ARCHES_COMMON=${WEB_ROOT}/bcgov-arches-common
 ENV ARCHES_COMPONENT_LAB=${WEB_ROOT}/arches-component-lab
 ENV NODE_MAJOR=20
+ENV DEBIAN_FRONTEND=noninteractive
 RUN mkdir -p ${APP_ROOT}/bcap/webpack
 
 RUN apt-get update && apt-get install -y make software-properties-common && apt-get install -y ca-certificates curl gnupg && mkdir -p /etc/apt/keyrings
@@ -16,17 +17,17 @@ RUN set -ex \
   && apt-get update -y \
   && RUN_DEPS=" \
   build-essential \
-  python3.11-dev \
-  mime-support \
+  python3-dev \
+  media-types \
   libgdal-dev \
-  python3.11 \
-  python3.11-distutils \
-  python3.11-venv \
+  python3 \
+  python3-venv \
   dos2unix \
   git \
   " \
   && apt-get install -y --no-install-recommends curl \
-  && apt-get install -y --no-install-recommends $RUN_DEPS 
+  && apt-get install -y --no-install-recommends $RUN_DEPS \
+  && rm -f /usr/lib/python3.12/EXTERNALLY-MANAGED
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py \
   && pip install setuptools python-dotenv django-storages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "bcap"
 version = "2.0.0a6"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 authors = []
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -18,7 +18,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]

--- a/tests/search_components/cross_model_advanced_search/README.md
+++ b/tests/search_components/cross_model_advanced_search/README.md
@@ -10,7 +10,7 @@ implementations return the same count.
 ### Playwright (inside of the `bcap7-6` container)
 
 ```bash
-python3.11 -m pip install playwright pytest-playwright
+python3 -m pip install playwright pytest-playwright
 playwright install --with-deps chromium
 ```
 
@@ -49,8 +49,8 @@ just unit
 just mock
 
 # Or inside the container
-python3.11 -m pytest tests/search_components/cross_model_advanced_search/unit/ -v
-python3.11 -m pytest tests/search_components/cross_model_advanced_search/mock/ -v
+python3 -m pytest tests/search_components/cross_model_advanced_search/unit/ -v
+python3 -m pytest tests/search_components/cross_model_advanced_search/mock/ -v
 ```
 
 ### Scenario Tests
@@ -65,7 +65,7 @@ the pipeline must produce. No database, Elasticsearch, or browser required.
 just scenario
 
 # Or inside the container
-python3.11 -m pytest tests/search_components/cross_model_advanced_search/scenario/ -v
+python3 -m pytest tests/search_components/cross_model_advanced_search/scenario/ -v
 ```
 
 To add a new scenario, append a `Scenario(...)` to `_build_scenarios()` in

--- a/tests/search_components/cross_model_advanced_search/justfile
+++ b/tests/search_components/cross_model_advanced_search/justfile
@@ -51,17 +51,17 @@ snapshot-update:
 # Run unit tests
 unit:
     {{ clr }}
-    docker exec -it -e PYTHONUNBUFFERED=1 {{ container }} python3.11 -m pytest {{ test_path }}/unit/ -v
+    docker exec -it -e PYTHONUNBUFFERED=1 {{ container }} python3 -m pytest {{ test_path }}/unit/ -v
 
 # Run mock tests
 mock:
     {{ clr }}
-    docker exec -it -e PYTHONUNBUFFERED=1 {{ container }} python3.11 -m pytest {{ test_path }}/mock/ -v
+    docker exec -it -e PYTHONUNBUFFERED=1 {{ container }} python3 -m pytest {{ test_path }}/mock/ -v
 
 # Run scenario tests
 scenario:
     {{ clr }}
-    docker exec -it -e PYTHONUNBUFFERED=1 {{ container }} python3.11 -m pytest {{ test_path }}/scenario/ -v
+    docker exec -it -e PYTHONUNBUFFERED=1 {{ container }} python3 -m pytest {{ test_path }}/scenario/ -v
 
 # Launch Chromium with remote debugging enabled
 [windows]


### PR DESCRIPTION
https://github.com/bcgov/nr-bcap/issues/1422

Ubuntu 22.04 is EOL -> Ubuntu 24.04

`python3.11` -> `python3` should replace it under CLI